### PR TITLE
[Attack Discovery] Attack Discovery 2.0: Workflows Integration 2 - Add discoveries plugin with workflow step registration

### DIFF
--- a/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
+++ b/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
@@ -45,6 +45,30 @@ export const APPROVED_STEP_DEFINITIONS: Array<{ id: string; handlerHash: string 
     handlerHash: '0223bec699354d5878732a6ebcb99a2b4b43a28b4f01da293df1ab7165c33e00',
   },
   {
+    id: 'attack-discovery.defaultAlertRetrieval',
+    handlerHash: '51903792b14368b373f46bfe5fddff0c3ed5bb883dc4f293d801c97716f76e1a',
+  },
+  {
+    id: 'attack-discovery.defaultValidation',
+    handlerHash: 'c6175267207c257503b8fc188bb0678b80a12fd2621c23d7b123e6f4cf629193',
+  },
+  {
+    id: 'attack-discovery.generate',
+    handlerHash: 'b03302995ec48b6e593a49622ce6e96936c7b1044e9a3cfcc7601b41a4104339',
+  },
+  {
+    id: 'attack-discovery.notify',
+    handlerHash: '5b65590179a2d438d7206f6aed206a3074afdfe875eb4720c938433a1681b5e7',
+  },
+  {
+    id: 'attack-discovery.persistDiscoveries',
+    handlerHash: 'f08fb12ffe138fdf7fd3e95424db2a625da2fe2e5c7ab95f362fa73b0090c690',
+  },
+  {
+    id: 'attack-discovery.run',
+    handlerHash: '79982c0abe31aa593b528807982c07f4949795341b252eea8daee9bef5a41771',
+  },
+  {
     id: 'data.concat',
     handlerHash: '611abd1e703d35528dd7dae76aa178aec0b02201a3a8cb26156ee9d9f03baa13',
   },

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -114,6 +114,7 @@ export const AGENT_BUILDER_BUILTIN_SKILLS = [
   'automatic_troubleshooting',
   'entity-analytics',
   'alert-analysis',
+  'attack-discovery-alert-retrieval-builder',
 
   // O11Y
   'observability.rca',

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/skills/type_definition.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/skills/type_definition.ts
@@ -36,7 +36,8 @@ export type SkillsDirectoryStructure = Directory<{
       alerts: FileDirectory<{
         rules: FileDirectory;
       }>;
-      entities: FileDirectory<{}>;
+      'attack-discovery': FileDirectory;
+      entities: FileDirectory;
       endpoint: FileDirectory<{}>;
       ml: FileDirectory<{}>;
     }>;

--- a/x-pack/solutions/security/packages/kbn-discoveries/impl/attack_discovery/generation/execute_generation_workflow.ts
+++ b/x-pack/solutions/security/packages/kbn-discoveries/impl/attack_discovery/generation/execute_generation_workflow.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Placeholder — real implementation added in PR 4
+
+export type ManualOrchestrationOutcome =
+  | {
+      outcome: 'validation_failed';
+    }
+  | {
+      alertRetrievalResult: {
+        alertsContextCount: number;
+        anonymizedAlerts: unknown[];
+      };
+      generationResult: {
+        attackDiscoveries: unknown[];
+        executionUuid: string;
+      };
+      outcome: 'validation_succeeded';
+      validationResult: {
+        generatedCount: number;
+      };
+    };
+
+export async function executeGenerationWorkflow(
+  _params: unknown
+): Promise<ManualOrchestrationOutcome> {
+  throw new Error('executeGenerationWorkflow: not implemented in this PR');
+}

--- a/x-pack/solutions/security/plugins/discoveries/README.md
+++ b/x-pack/solutions/security/plugins/discoveries/README.md
@@ -1,0 +1,816 @@
+# Discoveries Plugin
+
+Integrates Attack Discovery with the Kibana Workflows engine.
+
+## Overview
+
+This plugin implements Attack Discovery 2.0 by decoupling alert retrieval, generation, and validation into customizable workflow steps. It provides:
+
+- **Internal APIs** for generating and validating security insights
+- **Workflow Steps** for alert retrieval, generation, and validation
+- **Feature Flag** to enable/disable the functionality (`attackDiscoveryWorkflowsEnabled`)
+
+> **Hybrid Architecture**: Scheduling is always alerting-backed regardless of the feature flag state. The Alerting Framework owns scheduling, alert persistence, and action execution (with full throttling/frequency support). The Workflows engine owns only the generation pipeline (alert retrieval → generation → validation). This unified model ensures action frequency settings are always enforced.
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  @kbn/discoveries Package (server-only)                       │
+│  - LangGraph execution logic (graphs, orchestration)                │
+│  - Event logging utilities (shared with elastic_assistant)          │
+│  - Hallucination detection, anonymization, schedule transforms      │
+│  - Telemetry event definitions (EBT)                                │
+└────────────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────┐
+│  @kbn/discoveries-schemas Package (shared-common)             │
+│  - OpenAPI schemas (.schema.yaml)                                   │
+│  - Generated TypeScript types and Zod validators (.gen.ts)          │
+└────────────────────────────────────────────────────────────────────┘
+                               │
+                               ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  discoveries Plugin                                           │
+│  ┌──────────────────────────────────────────────────────────────┐  │
+│  │  Internal APIs:                                               │  │
+│  │  - POST /internal/attack_discovery/_generate                │  │
+│  │  - POST /internal/attack_discovery/_validate                │  │
+│  │  - Schedule CRUD (create/find/get/update/delete/enable/disable)│  │
+│  └──────────────────────────────────────────────────────────────┘  │
+│  ┌──────────────────────────────────────────────────────────────┐  │
+│  │  Workflow Steps:                                             │  │
+│  │  - attack-discovery.defaultAlertRetrieval                   │  │
+│  │  - attack-discovery.generate (with event logging)            │  │
+│  │  - attack-discovery.defaultValidation                        │  │
+│  │  - attack-discovery.persistDiscoveries                       │  │
+│  │  - attack-discovery.run (full pipeline in one step)          │  │
+│  └──────────────────────────────────────────────────────────────┘  │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+### Execution Flow
+
+```mermaid
+flowchart TB
+    subgraph Startup["Plugin Startup (setup/start lifecycle)"]
+        direction TB
+        REG["Register 5 workflow steps\n(tryRegisterStep with error tracking\n→ StepRegistrationResult)"]
+        DEFWF["Register 6 default workflow definitions\nper space (3 required + 3 examples)"]
+        HEALTH["Startup health check\n(steps registered? API available?)"]
+        REG --> DEFWF --> HEALTH
+    end
+
+    UI["Attack Discovery UI\nPOST /internal/attack_discovery/_generate"]
+    SCHED["Alerting Framework Scheduler\n(workflowExecutor)"]
+
+    UI --> RESOLVE
+    SCHED --> RESOLVE
+
+    subgraph PreFlight["Pre-Flight Checks (per request)"]
+        direction TB
+        RESOLVE["resolveDefaultWorkflowIds()\n(lazy init: create workflows if missing)"]
+        VERIFY{"verifyWorkflowIntegrity()\nSHA-256 hash comparison\nSelf-Healing Gateway"}
+        VALIDATE["validatePreExecution()\n(API, alerts index, connector checks)"]
+        RESOLVE --> VERIFY
+        VERIFY -->|"all_intact / repaired\n(workflow_modified telemetry)"| VALIDATE
+        VERIFY -->|repair_failed| ABORT["Abort: generation-failed event\n+ error in event log"]
+    end
+
+    subgraph Pipeline["3-Phase Orchestrated Pipeline"]
+        direction TB
+        R["Phase 1: Alert Retrieval Workflow\n(defaultAlertRetrieval step)\nalerts + anonymized_alerts + replacements"]
+        G["Phase 2: Generation Workflow\n(generate step + LangGraph)\nattack_discoveries + execution_uuid"]
+        V["Phase 3: Validation + Persistence Workflow\n(defaultValidation + persistDiscoveries)\nvalidated_discoveries persisted to index"]
+        R --> G --> V
+    end
+
+    VALIDATE -->|all checks OK| Pipeline
+
+    subgraph Observe["Observability Artifacts"]
+        direction LR
+        LOG["Server logs\n[execution: uuid] prefix\nINFO summary after every run"]
+        EVT["Event log\n(.kibana-event-log-*)\ngeneration-started/succeeded/failed"]
+        EBT["EBT telemetry\nmisconfiguration + step_failure events"]
+        WFUI["Workflows app UI\nper-step inputs/outputs/timing"]
+    end
+
+    Pipeline --> LOG
+    Pipeline --> EVT
+    Pipeline --> WFUI
+    VERIFY -->|"workflow_modified\n(repaired workflows)"| EBT
+    VALIDATE -->|"misconfiguration detected\n(missing index, bad connector)"| EBT
+    Pipeline -->|step failure| EBT
+```
+
+## Internal APIs
+
+### POST /internal/attack_discovery/_generate
+
+Kicks off the orchestrated pipeline (retrieve → generate → validate) asynchronously and returns an execution UUID for tracking. This endpoint does not accept pre-retrieved alerts and persists results via the validation step.
+
+**Request:**
+```typescript
+{
+  alerts_index_pattern: string,
+  api_config: ApiConfig,
+  filter?: Record<string, unknown>,
+  start?: string,
+  end?: string,
+  replacements?: Replacements,
+  size?: number,
+  workflow_config?: {
+    default_alert_retrieval_mode?: 'custom_query' | 'disabled' | 'esql',
+    alert_retrieval_workflow_ids?: string[],
+    validation_workflow_id?: string
+  }
+}
+```
+
+**Response:**
+```typescript
+{
+  execution_uuid: string
+}
+```
+
+### POST /internal/attack_discovery/_validate
+
+Validates generated attack discoveries and persists them to the Attack Discovery index as alerts.
+
+**Request:**
+```typescript
+{
+  attackDiscoveries: AttackDiscovery[],
+  anonymizedAlerts: Document[],
+  replacements?: Replacements,
+  apiConfig: ApiConfig,
+  connectorName: string,
+  generationUuid: string,
+  alertsContextCount: number,
+  enableFieldRendering?: boolean,
+  withReplacements?: boolean
+}
+```
+
+**Response:**
+```typescript
+{
+  validated_discoveries: AttackDiscoveryApiAlert[]
+}
+```
+
+## Workflow Steps
+
+| Step Type ID | Purpose | Inputs (summary) | Outputs (summary) |
+|---|---|---|---|
+| `attack-discovery.defaultAlertRetrieval` | Retrieves and anonymizes alerts using the legacy approach | `alertsIndexPattern`, `anonymizationFields`, `apiConfig`, `filter`, `size`, `start`/`end` | `alerts`, `anonymizedAlerts`, `replacements`, `apiConfig`, `connectorName`, `alertsContextCount` |
+| `attack-discovery.generate` | Generates attack discoveries from pre-retrieved alerts via LangGraph | `alerts`, `apiConfig`, `replacements`, `size` | `attack_discoveries`, `execution_uuid`, `replacements` |
+| `attack-discovery.defaultValidation` | Validates discoveries with hallucination detection and deduplication | `attackDiscoveries`, `anonymizedAlerts`, `apiConfig`, `connectorName`, `generationUuid`, `alertsContextCount`, `replacements` | `validated_discoveries`, `filtered_count`, `filter_reason` |
+| `attack-discovery.persistDiscoveries` | Persists validated discoveries to the Attack Discovery data store | `attackDiscoveries`, `anonymizedAlerts`, `apiConfig`, `connectorName`, `generationUuid`, `alertsContextCount`, `replacements` | `persisted_discoveries` |
+| `attack-discovery.run` | Runs the full pipeline (retrieve → generate → validate → persist) as a single step | `connector_id`, `alert_retrieval_mode`, `mode` (sync/async), `alerts` (optional), `size`, `start`/`end`, `filter`, `esql_query` | `attack_discoveries`, `execution_uuid`, `alerts_context_count`, `discovery_count` |
+
+### attack-discovery.defaultAlertRetrieval
+
+Retrieves and anonymizes alerts using the legacy approach for backwards compatibility.
+
+**Input:**
+- `alertsIndexPattern`: Alert index pattern
+- `anonymizationFields`: Fields to anonymize
+- `apiConfig`: Connector configuration
+- `filter`: Query filter
+- `size`: Max alerts to retrieve
+- `start`/`end`: Time range
+
+**Output:**
+- `alerts`: Retrieved alerts (string array)
+- `anonymizedAlerts`: Document objects
+- `replacements`: Anonymization map
+- `apiConfig`: Passed through
+- `connectorName`: Connector name
+- `alertsContextCount`: Number of alerts
+
+### attack-discovery.generate
+
+Generates attack discoveries from pre-retrieved alerts using LangGraph execution. **Includes event logging for generation tracking.**
+
+**Input:**
+- `alerts`: Pre-retrieved alerts (string array)
+- `apiConfig`: Connector configuration
+- `replacements`: Anonymization map
+- `size`: Max discoveries to generate
+
+**Output:**
+- `attack_discoveries`: Generated discoveries
+- `execution_uuid`: Workflow execution ID (for event log tracking)
+- `replacements`: Updated anonymization map
+
+**Event Logging:**
+- Emits `generation-started` event at beginning
+- Emits `generation-succeeded` event on success with metrics
+- Emits `generation-failed` event on error with failure reason
+- Events are queryable via `GET /api/attack_discovery/generations`
+
+### attack-discovery.defaultValidation (formerly default_promotion)
+
+Validates ALL generated discoveries with no additional enrichment or filtering.
+
+**Input:**
+- `attackDiscoveries`: Generated discoveries
+- `anonymizedAlerts`: Alert documents
+- `apiConfig`: Connector configuration
+- `connectorName`: Connector name
+- `generationUuid`: Generation ID
+- `alertsContextCount`: Alert count
+- `replacements`: Anonymization map
+- `enableFieldRendering`: Enable markdown syntax
+- `withReplacements`: Return with replacements applied
+
+**Output:**
+- `validated_discoveries`: Validated discoveries after hallucination detection and deduplication
+- `filtered_count`: Number of discoveries filtered out
+- `filter_reason`: Reason discoveries were filtered (optional)
+
+### attack-discovery.persistDiscoveries
+
+Persists validated attack discoveries to the ad-hoc Attack Discovery data store. This step handles authentication, space resolution, and writes discoveries as alerts to the Attack Discovery index.
+
+**Input:**
+- `alerts_context_count`: Number of alerts used in generation
+- `anonymized_alerts`: Anonymized alert documents
+- `api_config`: Connector configuration (must include `connector_id`)
+- `attack_discoveries`: Validated discoveries to persist
+- `connector_name`: Connector name
+- `enable_field_rendering`: Enable markdown syntax (default: `true`)
+- `generation_uuid`: Generation ID for tracing
+- `replacements`: Anonymization map
+- `with_replacements`: Return with replacements applied (default: `false`)
+
+**Output:**
+- `persisted_discoveries`: Discoveries written to the Attack Discovery index
+
+### attack-discovery.run
+
+High-level entry point that orchestrates the full Attack Discovery pipeline (retrieval → generation → validation → persistence) as a single step. Supports sync mode (returns discoveries inline) and async mode (returns `execution_uuid` immediately). The `replacements` map is intentionally excluded from output.
+
+**Input:**
+- `connector_id`: Connector ID (only required field)
+- `alert_retrieval_mode`: `'custom_query'` | `'disabled'` | `'esql'` | `'provided'` (default: `'custom_query'`)
+- `mode`: `'sync'` | `'async'` (default: `'sync'`)
+- `alerts`: Pre-retrieved alerts (string array, optional — used when `alert_retrieval_mode` is `'provided'`)
+- `size`, `start`, `end`, `filter`, `esql_query`: Alert retrieval parameters
+- `alert_retrieval_workflow_ids`, `validation_workflow_id`: Override default workflow IDs
+- `additional_context`: Extra context passed to the LLM
+
+**Output:**
+- `attack_discoveries`: Generated discoveries (null if none found, omitted in async mode)
+- `execution_uuid`: Execution UUID for event log tracking
+- `alerts_context_count`: Number of alerts analyzed
+- `discovery_count`: Number of discoveries generated
+
+## Event Logging
+
+The `attack-discovery.generate` workflow step emits events to the Elasticsearch event log for generation tracking. These events enable:
+
+- **Generation Status Tracking**: Monitor workflow execution progress
+- **Metrics Collection**: Track alert counts, discovery counts, and duration
+- **UI Integration**: Workflow-generated discoveries appear in the Attack Discovery UI
+- **API Integration**: Events are queryable via `GET /api/attack_discovery/generations`
+
+### Event Types
+
+1. **generation-started**: Emitted when generation begins
+2. **generation-succeeded**: Emitted on successful completion with metrics
+3. **generation-failed**: Emitted on error with failure reason
+
+### Event Structure
+
+Events follow the same structure as the public Attack Discovery API:
+
+```typescript
+{
+  '@timestamp': string,
+  event: {
+    action: 'generation-started' | 'generation-succeeded' | 'generation-failed',
+    dataset: string,  // Connector ID
+    duration?: number,  // Duration in nanoseconds
+    end?: string,  // ISO timestamp
+    outcome?: 'success' | 'failure',
+    provider: 'securitySolution.attackDiscovery',
+    reason?: string,  // For failed generations
+    start?: string  // ISO timestamp
+  },
+  kibana: {
+    alert: {
+      rule: {
+        consumer: 'siem',
+        execution: {
+          metrics?: {
+            alert_counts: {
+              active?: number,  // Alerts sent to LLM
+              new?: number  // Discoveries generated
+            }
+          },
+          status?: string,  // Loading message
+          uuid: string  // Execution UUID (ties events together)
+        }
+      }
+    },
+    space_ids: [string]
+  },
+  message: string,
+  tags: ['securitySolution', 'attackDiscovery'],
+  user: {
+    name: string
+  }
+}
+```
+
+### Shared Event Logging Utilities
+
+Event logging utilities are shared between `discoveries` and `elastic_assistant` plugins via the `@kbn/discoveries` package:
+
+- `writeAttackDiscoveryEvent`: Writes events to the event log
+- `getDurationNanoseconds`: Calculates duration in nanoseconds
+- Event action constants: `ATTACK_DISCOVERY_EVENT_LOG_ACTION_*`
+
+This eliminates code duplication and ensures consistent event structure across both the public API and workflow-based generation.
+
+## Observability & Debugging
+
+Attack Discovery produces three categories of observable artifacts. Together they let you trace any single execution end-to-end:
+
+| Artifact | Where | Default Level | Purpose |
+|----------|-------|---------------|---------|
+| **Server logs** | Kibana log output | INFO | Execution summary, startup health, pre-execution validation |
+| **Event log entries** | `.kibana-event-log-*` index | — | Generation tracking via `GET /api/attack_discovery/generations` |
+| **Workflow execution details** | Workflows app UI | — | Per-step status, inputs/outputs, timing |
+| **EBT telemetry** | Elastic analytics pipeline | — | Fleet-wide success/error/misconfiguration/step-failure metrics |
+
+### Tracing a Single Execution with `executionUuid`
+
+Every generation run is assigned a unique `executionUuid`. The traced logger prefixes **all** log messages for that run with `[execution: {uuid}]`, making it easy to filter logs for a single execution:
+
+```
+[2026-03-09T10:30:00.000Z][INFO ][plugins.discoveries] [execution: abc-123-def] Orchestration summary [succeeded] in 12345ms | alerts: 50, discoveries: 3
+```
+
+To filter for a specific execution:
+
+```bash
+# In Kibana server logs:
+grep "execution: abc-123-def" kibana.log
+```
+
+The same `executionUuid` appears in:
+- Server log messages (via the `[execution: {uuid}]` prefix)
+- Event log entries (as `kibana.alert.rule.execution.uuid`)
+- EBT telemetry events (as `execution_uuid` on `attack_discovery_step_failure`)
+- The API response from `POST /internal/attack_discovery/_generate`
+
+### INFO-Level Execution Summary
+
+After every orchestration run (success or failure), a single INFO-level summary is logged. This summary mirrors the Workflow Execution Details UI and is available with default logging settings:
+
+```
+[execution: abc-123-def] Orchestration summary [succeeded] in 12345ms | alerts: 50, discoveries: 3
+  retrieval: succeeded (4500ms) [default-attack-discovery-alert-retrieval] /app/workflows/default-attack-discovery-alert-retrieval?tab=executions&executionId=ret-run-id
+  generation: succeeded (6000ms) [attack-discovery-generation] /app/workflows/attack-discovery-generation?tab=executions&executionId=gen-run-id
+  validation: succeeded (1800ms) [attack-discovery-validate] /app/workflows/attack-discovery-validate?tab=executions&executionId=val-run-id
+```
+
+Each line includes:
+- **Step status**: `succeeded`, `failed`, or `not started`
+- **Duration**: Wall-clock time in milliseconds
+- **Workflow ID**: The workflow definition that was executed
+- **Link**: Clickable path to the Workflows app execution details page
+
+On failure, the failed step includes the error message:
+
+```
+[execution: abc-123-def] Orchestration summary [failed] in 6500ms | alerts: 50, discoveries: 0
+  retrieval: succeeded (4500ms) [default-attack-discovery-alert-retrieval] /app/workflows/...
+  generation: failed (2000ms) error="Request timed out after 10m"
+  validation: not started
+```
+
+### DEBUG-Level Health Checks
+
+Before each orchestration step, a DEBUG-level health check logs the preconditions. These have **zero cost** when debug logging is off (lazy evaluation via `logger.debug(() => ...)`).
+
+**Enable debug logging** in `kibana.dev.yml`:
+
+```yaml
+logging:
+  loggers:
+    - name: plugins.discoveries
+      level: debug
+```
+
+**Health check format**:
+
+```
+[execution: {uuid}] Health check [{step}]: key1=value1, key2=value2
+```
+
+**Preconditions checked per step**:
+
+| Step | Preconditions |
+|------|---------------|
+| **retrieval** | `alertsIndexPattern`, `anonymizationFieldCount`, `connectorId`, `customWorkflowIds`, `defaultAlertRetrievalWorkflowId`, `retrievalMode` |
+| **generation** | `alertCount`, `connectorId`, `generationWorkflowId` |
+| **validation** | `defaultValidationWorkflowId`, `discoveryCount`, `persist`, `validationWorkflowId` |
+
+**Example**:
+
+```
+[execution: abc-123-def] Health check [retrieval]: alertsIndexPattern=".alerts-security.alerts-default", anonymizationFieldCount=140, connectorId="my-connector-id", customWorkflowIds=[], defaultAlertRetrievalWorkflowId="default-attack-discovery-alert-retrieval", retrievalMode="custom_query"
+```
+
+### Startup Health Check
+
+When the plugin starts, it logs the result of a startup health check:
+
+- **Success** (INFO): `Startup health check passed: workflow steps registered, WorkflowsManagement API available`
+- **Failure** (WARN): `Startup health check found issues: {issue1}; {issue2}`
+
+Possible issues:
+- `Workflow steps were not registered`
+- `WorkflowsManagement API is not available`
+
+### Pre-Execution Validation
+
+Before the pipeline starts, concurrent checks validate all preconditions:
+
+| Check | Severity | Message |
+|-------|----------|---------|
+| WorkflowsManagement API | Critical | `WorkflowsManagement API is not available; cannot execute workflows` |
+| Default workflow IDs | Critical | `Default workflows could not be resolved; cannot execute workflows` |
+| Alerts index existence | Warning | `Alerts index '{pattern}' does not exist` |
+| Connector accessibility | Warning | `Connector '{id}' is not accessible: {error}` |
+
+Critical issues abort the pipeline. Warnings are logged but execution proceeds.
+
+- **All passed** (DEBUG): `Pre-execution validation passed: all checks OK`
+- **Critical issues** (WARN): `Pre-execution validation found {n} critical issue(s): {messages}`
+- **Warnings** (WARN): `Pre-execution validation found {n} warning(s): {messages}`
+
+Pre-execution misconfigurations also emit `attack_discovery_misconfiguration` EBT telemetry events (see [Telemetry README](server/lib/telemetry/README.md)).
+
+### Self-Healing / Workflow Integrity Verification
+
+Before the pipeline starts, the system verifies the integrity of the 3 required default workflows (alert retrieval, generation, validation). If any workflow has been deleted or modified since initial registration, it is automatically repaired. This runs between `resolveDefaultWorkflowIds()` and `validatePreExecution()` on every generation request.
+
+**Algorithm (runs in parallel for all 3 required workflows):**
+
+1. Fetch each workflow from Elasticsearch via the Workflows Management API
+2. **If missing**: attempt re-creation from the bundled YAML definition
+3. **If present**: compute SHA-256 hash of stored YAML and compare against the bundled hash
+4. **If hashes match**: no action needed (`all_intact`)
+5. **If hashes differ**: restore the workflow by overwriting with the bundled YAML (`repaired`)
+6. **If restore fails**: record as `unrepairableError`
+
+**Outcomes:**
+
+| Status | Meaning | Pipeline |
+|--------|---------|----------|
+| `all_intact` | All 3 workflows match bundled definitions | Continues |
+| `repaired` | One or more workflows were restored; `workflow_modified` telemetry emitted per repaired workflow | Continues |
+| `repair_failed` | One or more workflows could not be restored | **Aborted** — `generation-failed` event written with error reason |
+
+**Bundled YAML Hash Utility** ([`server/workflows/helpers/get_bundled_yaml_entries/`](server/workflows/helpers/get_bundled_yaml_entries/)):
+- Reads the 3 required YAML files from disk at first access
+- Computes SHA-256 hashes (using Node.js `crypto`) and caches results (bundled files are immutable at runtime)
+- Provides both the hash (for comparison) and the YAML (for restoration)
+
+**Error Visibility:**
+
+| Scenario | Log Level | Telemetry |
+|----------|-----------|-----------|
+| All intact | DEBUG | None |
+| Workflow modified, restoration succeeds | INFO | `workflow_modified` per workflow |
+| Workflow missing, re-creation succeeds | ERROR (detection) + INFO (success) | `workflow_modified` per workflow |
+| Repair fails | ERROR | None (execution aborted before telemetry) |
+
+**Key implementation files:**
+- Verify-and-repair logic: [`server/lib/workflow_initialization/verify_and_repair_workflows/`](server/lib/workflow_initialization/verify_and_repair_workflows/)
+- Service interface + implementation: [`server/lib/workflow_initialization/`](server/lib/workflow_initialization/)
+- Execution integration: [`@kbn/discoveries` `impl/attack_discovery/generation/verify_workflow_integrity/`](../../packages/kbn-discoveries/impl/attack_discovery/generation/verify_workflow_integrity/)
+
+### UI Form Validation
+
+The Attack Discovery settings flyout performs async runtime checks when workflow settings change:
+
+- **Workflow existence**: Verifies selected custom alert retrieval and validation workflows exist
+- **Workflow enabled**: Verifies selected workflows are enabled
+
+Issues are displayed in the validation callout:
+- **Errors** (red/danger): Configuration will definitely fail (e.g., no retrieval method selected)
+- **Warnings** (yellow/warning): Configuration may have issues (e.g., workflow not found, workflow disabled)
+
+### Troubleshooting Walkthrough
+
+**Scenario**: A user reports that Attack Discovery shows "0 new attacks discovered."
+
+1. **Check the execution summary** in the Kibana server log (INFO level, no config changes needed):
+
+   ```bash
+   grep "Orchestration summary" kibana.log | tail -5
+   ```
+
+   Look for the most recent execution. The summary shows which step failed and how long each step took.
+
+2. **Follow the workflow link** from the execution summary to view detailed inputs/outputs in the Workflows app.
+
+3. **Check for pre-execution warnings** (also INFO/WARN level):
+
+   ```bash
+   grep "Pre-execution validation" kibana.log | tail -5
+   ```
+
+   Common issues: alerts index doesn't exist, connector not accessible.
+
+4. **Enable DEBUG logging** for deeper investigation:
+
+   ```yaml
+   logging:
+     loggers:
+       - name: plugins.discoveries
+         level: debug
+   ```
+
+   Then reproduce the issue. Health checks before each step reveal the exact preconditions (alert count, connector ID, workflow IDs, etc.).
+
+5. **Check EBT telemetry** for fleet-wide patterns — see the [Telemetry README](server/lib/telemetry/README.md) for `attack_discovery_misconfiguration` and `attack_discovery_step_failure` events.
+
+## Feature Flag
+
+Enable in `kibana.yml`:
+
+```yaml
+feature_flags.overrides:
+  securitySolution.attackDiscoveryWorkflowsEnabled: true
+```
+
+## Development Status
+
+**Completed:**
+- ✅ Package structure with OpenAPI schemas
+- ✅ Generated TypeScript types
+- ✅ Plugin scaffolding
+- ✅ Internal API routes
+- ✅ Workflow step definitions
+- ✅ Feature flag
+- ✅ `attack-discovery.defaultAlertRetrieval` step
+- ✅ `attack-discovery.generate` step with LangGraph execution
+- ✅ `attack-discovery.defaultValidation` step
+- ✅ `attack-discovery.persistDiscoveries` step
+- ✅ Event logging for generation tracking (shared utilities with elastic_assistant)
+- ✅ Comprehensive unit tests for event logging utilities
+- ✅ End-to-end workflow (retrieve → generate → validate)
+- ✅ Traced logger with `[execution: {uuid}]` prefix for all log messages
+- ✅ INFO-level execution summary with per-step status, timing, and workflow links
+- ✅ DEBUG-level health checks before each orchestration step
+- ✅ Startup health check in plugin `start()` lifecycle
+- ✅ Pre-execution validation (alerts index, connector, default workflows)
+- ✅ UI form validation with async workflow existence/enabled checks
+- ✅ EBT telemetry for misconfigurations and per-step failures
+- ✅ `attack-discovery.run` step (full pipeline in one step, sync/async modes)
+- ✅ Self-healing / workflow integrity verification (SHA-256 hash comparison, verify-and-repair)
+- ✅ Step registration error tracking (`StepRegistrationResult` with failed/registered lists)
+- ✅ Bundled YAML hash utility for integrity comparison (`get_bundled_yaml_entries`)
+- ✅ `workflow_modified` misconfiguration telemetry for self-healing events
+
+## Dependencies
+
+- `@kbn/workflows-plugin` — Workflow engine (required)
+- `@kbn/discoveries` — Shared server-side business logic and event logging utilities
+- `@kbn/discoveries-schemas` — OpenAPI-generated types and Zod validators for route validation
+- `@kbn/attack-discovery-schedules-common` — Shared schedule infrastructure (data client, transforms, field map)
+- `@kbn/actions-plugin` — Connector execution (required)
+- `@kbn/alerting-plugin` — Schedule rule registration (required)
+- `@kbn/event-log-plugin` — Event logging for generation tracking (required)
+- `@kbn/security-plugin` — User authentication (required)
+- `@kbn/spaces-plugin` — Space ID resolution (optional)
+- `@kbn/elastic-assistant-plugin` — Optional executor registration for scheduled workflow execution
+
+## Testing
+
+See:
+
+- `TESTING_INSTRUCTIONS.md`
+- `WORKFLOW_TESTING_RESULTS.md`
+
+## Architecture Decisions
+
+This section documents the key design decisions behind the Attack Discovery 2.0 workflow integration. It targets a workflows-expert tech lead reviewing the PR and explains the _why_ behind each choice.
+
+### Why Workflows
+
+Attack Discovery 1.0 was a monolithic endpoint: one HTTP handler retrieved alerts, invoked the LLM, validated results, and persisted discoveries — all inline. This made the pipeline opaque to operators and impossible to customize without forking the plugin.
+
+Workflows unlock four capabilities that the monolithic approach cannot provide:
+
+1. **Observability**: Each pipeline phase (retrieval, generation, validation) executes as a distinct workflow run. The Workflows app shows per-step status, inputs, outputs, and timing — no `DEBUG` logging required.
+2. **Customizability**: Users replace any phase by pointing at a different workflow ID. A team can swap the default DSL-based retrieval for an ES|QL query (see `attack_discovery_esql_example.workflow.yaml`) without modifying plugin code.
+3. **Composability**: Workflow steps are reusable building blocks. The `attack-discovery.generate` step can appear in a user-authored workflow alongside custom pre-processing or post-processing steps, with data threaded via Liquid expressions.
+4. **Scheduling**: The same steps power both the interactive `_generate` endpoint and the alerting-framework-based scheduler (`workflowExecutor`), eliminating separate code paths for on-demand vs. scheduled generation.
+
+### Step Registration Strategy: Two-Tier Model
+
+Steps are organized into two tiers based on their intended audience:
+
+| Tier | Audience | Steps | Registration |
+|------|----------|-------|-------------|
+| **User-facing** | Workflow authors (via YAML) | `defaultAlertRetrieval`, `generate`, `defaultValidation`, `persistDiscoveries`, `run` | Registered in `plugin.setup()`, visible in step catalog |
+| **Internal** | Plugin code only | Pipeline orchestration, event logging, pre-execution validation, integrity verification | Not registered as steps; implemented as helper functions |
+
+**Why two tiers?** Registered steps carry a public contract: their input/output schemas become the API surface that user-authored workflows depend on. Anything that does not need to be referenced from YAML stays as an internal helper to avoid inflating the catalog with implementation details.
+
+Each registered step has a **common definition** (`common/step_types/*.ts`) containing the `id`, `inputSchema`, `outputSchema`, `label`, `description`, and `category`. This definition is shared between server-side handler registration and the step catalog UI. The server-side handler (`server/workflows/steps/*/get_*_step_definition.ts`) wraps the common definition with `createServerStepDefinition` and provides the actual implementation.
+
+### Ergonomics Design
+
+#### Why a `run` Step
+
+The four existing steps each handle one phase of the pipeline. To generate discoveries, a workflow author currently must compose all four steps and thread intermediate data between them via Liquid expressions — a non-trivial amount of boilerplate:
+
+```yaml
+steps:
+  - name: retrieve
+    type: attack-discovery.defaultAlertRetrieval
+    with:
+      alerts_index_pattern: ${{ inputs.alerts_index_pattern }}
+      anonymization_fields: ${{ inputs.anonymization_fields }}
+      api_config: ${{ inputs.api_config }}
+      # ... 6 more fields
+  - name: generate
+    type: attack-discovery.generate
+    with:
+      alerts: ${{ steps.retrieve.output.alerts }}
+      api_config: ${{ steps.retrieve.output.api_config }}
+      replacements: ${{ steps.retrieve.output.replacements }}
+      # ...
+  - name: validate
+    type: attack-discovery.defaultValidation
+    with:
+      attack_discoveries: ${{ steps.generate.output.attack_discoveries }}
+      anonymized_alerts: ${{ steps.retrieve.output.anonymized_alerts }}
+      # ... 7 more fields threaded from prior steps
+  - name: persist
+    type: attack-discovery.persistDiscoveries
+    with:
+      # ... similarly verbose
+```
+
+The `attack-discovery.run` step collapses this into a single step that runs the full pipeline internally:
+
+```yaml
+steps:
+  - name: discover
+    type: attack-discovery.run
+    with:
+      connector_id: ${{ inputs.connector_id }}
+```
+
+This dramatically reduces the surface area a workflow author must understand. Advanced users who need to inject custom logic between phases can still compose the individual steps directly.
+
+#### `api_config` Simplification
+
+The `run` step takes a `connector_id` directly (not a full `api_config` object). Every connector already knows its own action type, so requiring the caller to provide both `action_type_id` and `connector_id` is redundant and error-prone. The step resolves the action type from the connector at runtime.
+
+#### Why `run` Does Not Use `workflow.execute` Composition
+
+An alternative design would have the `run` step call `workflow.execute` internally to invoke the existing generation workflow. This was rejected for three reasons:
+
+1. **Timeout nesting**: A step executing a workflow creates a nested timeout boundary. The outer step timeout must be strictly greater than the inner workflow timeout, which is fragile and hard for users to reason about.
+2. **Observability gap**: The inner workflow execution would appear as a single opaque step in the parent workflow's execution details, losing the per-phase visibility that workflows provide.
+3. **Error propagation**: Failures in the inner workflow must be unwrapped and re-thrown with meaningful context, adding complexity without benefit over direct function composition.
+
+### Sync/Async Mode Design
+
+The `run` step supports two modes:
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| **async** (default) | Returns `{ execution_uuid }` immediately; discoveries arrive via event log | Interactive UI, scheduled generation |
+| **sync** | Blocks until pipeline completes; returns `{ attack_discoveries }` | Agent Builder tools, automation scripts |
+
+**Why two modes?** The existing `_generate` endpoint is async because LLM generation can take minutes and HTTP requests should not block that long. However, Agent Builder tools and workflow steps that compose AD need the result inline — they cannot poll the event log. Sync mode serves this use case.
+
+The mode is selected via a `mode` enum input (`'sync'` or `'async'`), not via separate step type IDs, because the underlying pipeline logic is identical — only the response envelope differs.
+
+### Why `_generate` Stays Async
+
+The `POST /internal/attack_discovery/_generate` endpoint remains async (returns `execution_uuid`, not discoveries) for five structural reasons:
+
+1. **HTTP timeout budget**: Generation routinely takes 2–5 minutes. Kibana's default idle socket timeout is 2 minutes. Extending it to 10 minutes risks proxy/load-balancer timeouts in production.
+2. **UI responsiveness**: The Attack Discovery UI shows a loading state with progress messages immediately after the request returns. If `_generate` blocked, the UI would appear frozen with no feedback.
+3. **Event log contract**: The UI polls `GET /api/attack_discovery/generations` for status. This event-log-based contract allows multiple browser tabs and the scheduler to observe the same execution, which a synchronous response cannot support.
+4. **Retry safety**: If the browser disconnects during a long-running sync request, the generation is lost. With async, the pipeline runs server-side to completion regardless of client state.
+5. **Scheduling parity**: The alerting-framework scheduler (`workflowExecutor`) invokes the same `executeGenerationWorkflow` function. Making `_generate` async keeps the same code path for both triggers; a sync variant would need a separate code path.
+
+### Why `_generate/graph` Was Removed
+
+The `POST /internal/attack_discovery/_generate/graph` endpoint accepted pre-retrieved alerts and ran only the generation step (no validation, no persistence). It was removed because:
+
+1. **Orphaned results**: Generated discoveries were never persisted, so they were invisible to the UI and event log — effectively lost after the response.
+2. **Bypassed safety checks**: Skipping validation meant hallucinated alert IDs could appear in results without detection.
+3. **Superseded by `run` step**: The `run` step in sync mode provides the same "generate from pre-retrieved alerts" capability but with proper validation and a contract for returning results.
+4. **Maintenance cost**: Two generation endpoints with different validation behavior doubled the test surface without serving a real user need.
+
+### Timeout Architecture
+
+Generation spans three workflow executions (retrieval, generation, validation), each with its own timeout. The timeout architecture uses a layered model with a 10-minute total budget:
+
+```mermaid
+gantt
+    title Attack Discovery Timeout Budget (10 min total)
+    dateFormat X
+    axisFormat %M:%S
+
+    section HTTP Layer
+    Route handler idle socket   :a1, 0, 600
+
+    section Workflow Layer
+    Alert retrieval (5 min max)  :a2, 0, 300
+    Generation (10 min max)      :a3, 300, 600
+    Validation (2 min max)       :a4, 600, 720
+
+    section LLM Layer
+    Connector timeout per call   :a5, 300, 540
+```
+
+| Layer | Timeout | Controls |
+|-------|---------|----------|
+| **HTTP route handler** | 10 min (`DEFAULT_ROUTE_HANDLER_TIMEOUT_MS`) | Kibana idle socket timeout; prevents the connection from being reaped during long runs |
+| **Workflow step** | Per-step (`timeout` field in YAML) | Retrieval: 5 min, Generation: 10 min. If a step exceeds its timeout, the workflow engine cancels it |
+| **Connector (LLM call)** | `connectorTimeout` (passed to step) | Individual LLM API call timeout. Multiple calls may occur within a single generation (e.g., LangGraph retries) |
+| **Polling** | Intervals set by orchestrator | The pipeline orchestrator polls workflow completion status; polling intervals should be shorter than step timeouts |
+
+**Design principle**: Each layer's timeout should be strictly less than or equal to the layer above it. The HTTP route handler timeout is the outermost boundary; individual LLM calls are the innermost. This ensures that timeouts propagate from the inside out: a slow LLM call triggers a connector timeout, which triggers a step failure, which the orchestrator catches and reports — rather than the HTTP connection silently closing.
+
+### Security Considerations
+
+#### Strict `string[]` Alert Contract
+
+The `attack-discovery.generate` step accepts alerts as `string[]` — not as structured alert objects. This is a deliberate security boundary:
+
+1. **Anonymization enforcement**: By the time alerts reach the generation step, they have already been transformed by the retrieval step into anonymized string representations. The string type makes it impossible to accidentally pass raw alert objects containing PII to the LLM.
+2. **Schema simplicity**: A `string[]` schema cannot carry nested fields that might leak sensitive data. The contract is unambiguous: each element is a single anonymized text representation of an alert.
+3. **Liquid expression safety**: In user-authored workflows, Liquid expressions can pass `string[]` values between steps. If the contract were a complex object type, Liquid filters could inadvertently expose nested sensitive fields.
+
+#### Anonymization Boundary
+
+The anonymization boundary sits at the **alert retrieval** step:
+
+```
+Raw alerts (Elasticsearch) → [anonymization boundary] → Anonymized strings → LLM → Discoveries
+```
+
+Everything upstream of the retrieval step output operates on raw data. Everything downstream operates on anonymized data. The `replacements` map (mapping anonymized tokens back to real values) is the only bridge between the two worlds.
+
+The `defaultAlertRetrieval` step also ensures the `_id` field is always present in the anonymization configuration (via `ensureRequiredAnonymizationFields`). This is required because downstream steps use real alert IDs for hallucination detection — IDs are allowed but not anonymized.
+
+#### Liquid Filter Pattern
+
+User-authored workflows use Liquid expressions to thread data between steps. The Liquid template engine runs in a sandboxed environment where:
+
+- Only step outputs and workflow inputs are accessible (no access to server internals)
+- Built-in Liquid filters (e.g., `| sort: "title"`, `| size`) operate on the data without side effects
+- No custom Liquid tags or filters are registered that could access the filesystem, network, or Kibana internals
+
+The custom validation example (`attack_discovery_custom_validation_example.workflow.yaml`) demonstrates this pattern: it uses `| sort: "title"` between the validation and persist steps to reorder discoveries — a transformation that requires no custom step code.
+
+### Replacements Map Security Boundary
+
+The `replacements` map (`Record<string, string>`) maps anonymized tokens (e.g., `"SRVHQMWPN001"`) back to real values (e.g., `"dc01.example.com"`). This map is sensitive because it is the key to de-anonymizing all LLM-visible data.
+
+**Where the replacements map flows:**
+
+| Step | Receives | Returns |
+|------|----------|---------|
+| `defaultAlertRetrieval` | Optional initial replacements | Updated replacements (new tokens from anonymization) |
+| `generate` | Replacements from retrieval | Updated replacements (LLM may create new mappings) |
+| `defaultValidation` | Replacements from generation | Not in output (consumed internally for hallucination check) |
+| `persistDiscoveries` | Replacements from generation | Not in output (consumed internally for de-anonymized persistence) |
+| `run` | Optional initial replacements | **Excluded from output** (security boundary) |
+
+**Key invariant**: The `run` step deliberately excludes the replacements map from its output. A workflow that invokes `run` receives discoveries but cannot access the de-anonymization key. This prevents user-authored workflows from inadvertently logging or forwarding the replacements to external systems.
+
+### Agent Builder Interaction Model
+
+Attack Discovery steps can be invoked from Agent Builder tools. The interaction matrix shows which combinations are supported:
+
+| Agent Builder Pattern | Steps Used | Mode | Returns |
+|-----------------------|------------|------|---------|
+| **Full pipeline** | `run` | sync | `attack_discoveries`, `execution_uuid`, `discovery_count` |
+| **Custom retrieval + generation** | `defaultAlertRetrieval` → `generate` | sync | `attack_discoveries`, `replacements` |
+| **Generation only** (pre-retrieved alerts) | `generate` | sync | `attack_discoveries`, `execution_uuid`, `replacements` |
+| **Validation only** | `defaultValidation` | sync | `validated_discoveries`, `filtered_count` |
+
+**Recommended pattern**: Use the `run` step in sync mode. It handles the full pipeline internally, returns only the discoveries (no sensitive replacements map), and presents a minimal input surface (`connector_id` is the only required field when defaults are acceptable).
+
+**Why sync mode for Agent Builder?** Agent Builder tools execute as part of a larger agent conversation. The agent needs the result inline to formulate its response. Async mode would require the agent to poll for results, which is not supported in the current Agent Builder execution model.
+
+The `_generate_workflow` endpoint demonstrates an existing Agent Builder integration: it uses the `alertRetrievalBuilderSkill` to generate custom alert retrieval workflows via an LLM agent. This endpoint composes Agent Builder's `runAgent` with the Workflows Management API, showing how the two systems interact.
+

--- a/x-pack/solutions/security/plugins/discoveries/STACK.md
+++ b/x-pack/solutions/security/plugins/discoveries/STACK.md
@@ -1,0 +1,898 @@
+# Attack Discovery 2.0 Workflows Integration: PR Stack Plan
+
+> This document drives the code review and later the creation of a stacked PR series for the `attack_discovery_workflows_integration` feature branch.
+>
+> **Guiding principle**: Each PR in the stack MUST be independently mergeable without impacting production. The feature flag `securitySolution.attackDiscoveryWorkflowsEnabled` gates all new behavior.
+
+---
+
+## Branch Summary
+
+- **Feature branch**: `attack_discovery_workflows_integration`
+- **Feature commits**: 5 (ff51c50d25ac..HEAD)
+- **Scope**: ~1,006 files changed, ~125k insertions, ~2.6k deletions
+- **New packages**: 3 (`kbn-discoveries`, `kbn-discoveries-schemas`, `kbn-attack-discovery-schedules-common`)
+- **New plugin**: 1 (`discoveries`)
+- **Modified plugins**: `elastic_assistant`, `security_solution` (public + server), workflows platform plugins (registrations only)
+
+---
+
+## PR Stack
+
+### PR 1: Feature Flag + Shared Packages + elastic_assistant Refactor
+
+**Goal**: Extract shared logic from `elastic_assistant` into reusable packages and prove zero regression when the feature flag is OFF.
+
+<details>
+<summary><strong>Commit Message</strong></summary>
+
+## [Security Solution] [Attack Discovery] Extract shared packages and refactor elastic_assistant
+
+This PR extracts shared server-side logic from `elastic_assistant` into three new reusable packages, preparing the codebase for the upcoming Attack Discovery Workflows integration. All existing behavior is unchanged — this is a pure structural refactor with no new features.
+
+The extraction enables both the existing `elastic_assistant` plugin and the upcoming `discoveries` plugin to share LangGraph execution logic, event logging utilities, schedule infrastructure, and API type definitions without duplication.
+
+### Feature Flag
+
+Introduces `securitySolution.attackDiscoveryWorkflowsEnabled` (default: `false`). No behavior changes when the flag is OFF — this PR only defines it.
+
+```yaml
+feature_flags.overrides:
+  securitySolution.attackDiscoveryWorkflowsEnabled: true
+```
+
+### New Packages
+
+| Package | Purpose |
+|---------|---------|
+| `@kbn/discoveries` | Shared server-side logic: LangGraph graphs, event logging utilities, hallucination detection, anonymization, schedule transforms, telemetry definitions. Consumed by both `elastic_assistant` and the upcoming `discoveries` plugin. |
+| `@kbn/discoveries-schemas` | OpenAPI schemas (`.schema.yaml`), generated TypeScript types, and Zod validators for route validation. |
+| `@kbn/attack-discovery-schedules-common` | Shared schedule infrastructure: data client, field map, transforms. Extracted from `elastic_assistant` to keep things DRY. |
+
+### What Moved
+
+| From (`elastic_assistant`) | To | Notes |
+|---|---|---|
+| `server/lib/attack_discovery/graphs/` | `@kbn/discoveries` `impl/attack_discovery/graphs/` | LangGraph graph, hallucination detection, anonymization |
+| `server/lib/attack_discovery/persistence/event_logging/` | `@kbn/discoveries` `impl/attack_discovery/persistence/event_logging/` | Event logging utilities |
+| `server/lib/attack_discovery/schedules/` | `@kbn/attack-discovery-schedules-common` | Data client, field map, transforms |
+| `server/lib/defend_insights/graphs/` | `@kbn/discoveries` `impl/defend_insights/graphs/` | Defend insights graph (code move, no logic changes) |
+
+`elastic_assistant` now imports from the shared packages instead of local files. All existing public API routes, defend insights functionality, and schedule behavior are unchanged.
+
+### Defend Insights Migration
+
+The defend insights graph code is relocated from `elastic_assistant` to `@kbn/discoveries`. This is a pure code move with import path updates — no logic changes. The `@elastic/security-defend-workflows` team expects this migration.
+
+</details>
+
+**Scope**:
+- Feature flag definition: `securitySolution.attackDiscoveryWorkflowsEnabled`
+- `@kbn/discoveries` package: LangGraph execution logic, event logging utilities, hallucination detection, anonymization, schedule transforms, telemetry event definitions (moved from `elastic_assistant`)
+- `@kbn/discoveries-schemas` package: OpenAPI schemas, generated TypeScript types, Zod validators
+- `@kbn/attack-discovery-schedules-common` package: data client, field map, transforms, schedule params (moved from `elastic_assistant`)
+- `x-pack/solutions/security/packages/features/` updates (action constants, privilege analysis tests)
+- `x-pack/platform/packages/shared/kbn-elastic-assistant-common/` schema additions (generation, schedules)
+- All corresponding deletions from `elastic_assistant` (graph code, schedule data client, field maps, defend insights graphs)
+- `elastic_assistant` re-consumption of the shared packages
+- Build config: `tsconfig.base.json`, `tsconfig.refs.json`, `kbn-ts-projects/config-paths.json`, `package.json`
+
+**Review objectives** (from review.md):
+- [G1] Attack discovery + schedules work when FF is OFF
+- [G2] Defend insights still works (graph code moved but re-consumed)
+- [G4] All of the above for serverless
+- [G7] One function per file with unit tests
+- [G10] No accidental artifacts (API keys, cursor/claude configs)
+- [G13] No core Kibana platform modifications (only registrations)
+
+**Review checklist**:
+- [ ] `elastic_assistant` imports from `@kbn/discoveries` and `@kbn/attack-discovery-schedules-common` instead of deleted local files
+- [ ] Defend insights graph is intact and invoked the same way
+- [ ] All existing public API routes in `elastic_assistant` are unchanged in behavior
+- [ ] No new exports leak workflow-only types into the public API
+- [ ] Feature flag default is `false`
+- [ ] Build passes: `yarn kbn bootstrap`, type check, lint
+- [ ] Existing jest tests in `elastic_assistant` pass without modification (or are updated to use new import paths only)
+
+---
+
+### PR 2: Discoveries Plugin Scaffold + Workflow Step Registration
+
+**Goal**: Introduce the `discoveries` plugin with lifecycle setup/start, workflow step registration, and default workflow definitions.
+
+<details>
+<summary><strong>Commit Message</strong></summary>
+
+## [Security Solution] [Attack Discovery] Add discoveries plugin with workflow step registration
+
+This PR introduces the `discoveries` plugin, which implements the Attack Discovery Workflows integration. The plugin registers five workflow steps at `setup()` and creates six default workflow definitions at `start()`.
+
+The plugin is gated by the `securitySolution.attackDiscoveryWorkflowsEnabled` feature flag. When the flag is OFF, the plugin performs no work and has zero side effects.
+
+```yaml
+feature_flags.overrides:
+  securitySolution.attackDiscoveryWorkflowsEnabled: true
+```
+
+### Workflow Steps
+
+| Step Type ID | Category | Purpose |
+|---|---|---|
+| `attack-discovery.defaultAlertRetrieval` | Elasticsearch | Retrieves and anonymizes alerts using query DSL or ES\|QL |
+| `attack-discovery.generate` | AI | Generates attack discoveries from pre-retrieved alerts via LangGraph; emits event log entries |
+| `attack-discovery.defaultValidation` | Kibana | Validates discoveries with hallucination detection and deduplication |
+| `attack-discovery.persistDiscoveries` | Kibana | Persists validated discoveries to the Attack Discovery data store |
+| `attack-discovery.run` | AI | High-level entry point: runs the full pipeline as a single step (sync or async) |
+
+Steps use `@kbn/zod/v4` inline schemas (not generated v3 schemas) per the Workflows platform requirement. Each step has a common definition in `common/step_types/` shared between server registration and the step catalog UI.
+
+### Default Workflow Definitions
+
+| Workflow YAML | Purpose |
+|---------------|---------|
+| `default_attack_discovery_alert_retrieval` | Default alert retrieval (query DSL) — _required_ |
+| `attack_discovery_generation` | Generation via LangGraph — _required_ |
+| `attack_discovery_validate` | Validation + persistence — _required_ |
+| `attack_discovery_esql_example` | Example: ES\|QL-based alert retrieval |
+| `attack_discovery_custom_validation_example` | Example: custom validation with Liquid sort filter |
+| `attack_discovery_run_example` | Example: full pipeline in one step |
+
+### Platform Registrations
+
+- `approved_step_definitions.ts`: 6 `attack-discovery.*` step entries (+24 lines)
+- `agent-builder allow_lists.ts`: `'attack-discovery-alert-retrieval-builder'` skill (+1 line)
+- `agent-builder type_definition.ts`: `'attack-discovery'` directory entry (+2 lines)
+
+### Plugin Lifecycle
+
+1. **`setup()`**: Registers 5 workflow steps via `tryRegisterStep` (with error tracking via `StepRegistrationResult`)
+2. **`start()`**: Registers default workflow definitions per space, runs startup health check
+
+</details>
+
+**Scope**:
+- `x-pack/solutions/security/plugins/discoveries/` plugin scaffold (`kibana.jsonc`, `plugin.ts`, `types.ts`, `index.ts`)
+- `common/step_types/` — 5 common step definitions (using `@kbn/zod/v4` inline schemas)
+- `server/workflows/register_workflow_steps.ts` — step registration with `tryRegisterStep` error tracking (`StepRegistrationResult`)
+- `server/workflows/steps/` — 5 step handler implementations:
+  - `default_alert_retrieval_step/`
+  - `generate_step/`
+  - `default_validation_step/`
+  - `persist_discoveries_step/`
+  - `run_step/`
+- `server/workflows/definitions/` — 6 bundled YAML workflow definitions (3 required + 3 examples)
+- `server/workflows/register_default_workflows.ts` — default workflow registration per space
+- `server/workflows/helpers/` — `get_bundled_yaml_entries/`, `read_bundled_workflow_yaml/`, `resolve_connector_details/`
+- Platform registrations:
+  - `workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts` (6 new step hashes)
+  - `agent-builder-server/allow_lists.ts` (new skill allowlist entry)
+  - `agent-builder-server/skills/type_definition.ts` (new directory structure)
+
+**Review objectives**:
+- [G1] Plugin only activates when FF is ON; zero side effects when OFF
+- [G5] All new internal routes use `snake_case`
+- [G7] One function per file with unit tests
+- [G8] Most functions are pure, no side effects
+- [G9] No unnecessary mutation (no push/pop, prefer map/reduce)
+- [G13] Platform changes are registrations ONLY — no behavioral modifications to workflows engine, agent builder, or management service
+- [S1] Artifact creation at plugin lifecycle setup/start
+
+**Review checklist**:
+- [ ] Plugin `setup()` registers steps; `start()` registers default workflows and runs startup health check
+- [ ] Step schemas use `@kbn/zod/v4` (NOT v3 from generated schemas) per `workflows_zod_version.md`
+- [ ] `tryRegisterStep` handles failures gracefully and reports `StepRegistrationResult`
+- [ ] Default workflow YAMLs are valid and reference correct step type IDs
+- [ ] Bundled YAML hash utility correctly computes SHA-256 and caches
+- [ ] Plugin `kibana.jsonc` declares correct required/optional dependencies
+- [ ] All step handler implementations delegate to helpers (not monolithic handlers)
+
+---
+
+### PR 3: Internal API Routes + ES|QL Mode
+
+**Goal**: Implement the internal HTTP API surface for the discoveries plugin, including ES|QL-based alert retrieval as an alternative to query DSL.
+
+<details>
+<summary><strong>Commit Message</strong></summary>
+
+## [Security Solution] [Attack Discovery] Add internal API routes and ES|QL alert retrieval mode
+
+This PR implements the internal HTTP API surface for the `discoveries` plugin and adds ES|QL-based alert retrieval as an alternative to the default query DSL mode.
+
+All routes are gated by the `attackDiscoveryWorkflowsEnabled` feature flag and return 404 when the flag is OFF. Every route uses `asCurrentUser` for Elasticsearch operations and matches the existing Attack Discovery RBAC privileges.
+
+```yaml
+feature_flags.overrides:
+  securitySolution.attackDiscoveryWorkflowsEnabled: true
+```
+
+### Internal APIs
+
+| Method | Route | Purpose |
+|--------|-------|---------|
+| POST | `/internal/attack_discovery/_generate` | Kicks off the orchestrated pipeline asynchronously; returns `execution_uuid` |
+| POST | `/internal/attack_discovery/_validate` | Validates and persists generated discoveries |
+| POST | `/internal/attack_discovery/_generate/workflow` | Generates a custom alert retrieval workflow via AI |
+| GET | `/internal/attack_discovery/pipeline_data` | Returns pipeline execution data for the monitoring UI |
+| GET | `/internal/attack_discovery/execution_tracking` | Returns workflow execution tracking data |
+| GET | `/internal/attack_discovery/default_esql_query` | Returns the default ES\|QL query for alert retrieval |
+| — | Schedule CRUD (create/find/get/update/delete/enable/disable) | Full schedule management via internal routes |
+
+### Schedule API Isolation
+
+Internal schedules use a bidirectional tag strategy: `applyTags` tags every write with `attack-discovery-schedule`, and `filterTags` restricts reads to only that tag. This ensures the internal API never surfaces schedules created by the public API (and vice versa). This isolation is a data safety measure — cross-API mutation would cause silent data loss because the public API's update path performs full parameter replacement without `workflowConfig`.
+
+### ES|QL Alert Retrieval
+
+The `default_esql_query` route returns a pre-built ES|QL query that replicates the behavior of the default DSL query (open/acknowledged alerts, sorted by risk score, excluding building blocks). The ES|QL mode is available as a `default_alert_retrieval_mode` option alongside `custom_query` and `disabled`.
+
+The `attack_discovery_esql_example.workflow.yaml` bundled definition demonstrates custom alert retrieval using `elasticsearch.esql.query`, serving as a reference for teams building custom retrieval workflows.
+
+</details>
+
+**Scope**:
+- `server/routes/index.ts` — route registration
+- `POST /internal/attack_discovery/_generate` (`server/routes/post/generate/post_generate.ts`)
+  - Helpers: `get_inferred_prebuilt_step_types/`
+- `POST /internal/attack_discovery/_validate` (`server/routes/post/validate/post_validate.ts`)
+  - Helpers: `bulk_response_helpers`, `get_ids_query`, `get_markdown_fields`, `is_missing_required_fields`, `transform_*`, `validate_attack_discoveries`
+- `POST /internal/attack_discovery/_generate/workflow` (`server/routes/post/generate_workflow/post_generate_workflow.ts`)
+  - Helpers: `build_skill_configuration_overrides/`, `extract_workflow_yaml/`, `generate_workflow_with_retries/`, `invoke_agent/`, `validate_workflow_yaml/`
+- Schedule CRUD routes (`server/routes/post/schedules/`, `server/routes/get/schedules/`, `server/routes/put/schedules/`, `server/routes/delete/schedules/`)
+- `GET /internal/attack_discovery/action_triggered_generations` (`server/routes/get/action_triggered_generations/`)
+- `GET /internal/attack_discovery/execution_tracking` (`server/routes/get/execution_tracking/`)
+- `GET /internal/attack_discovery/pipeline_data` (`server/routes/get/pipeline_data/`)
+  - Helpers: `compute_combined_alerts/`, `extract_pipeline_alert_data/`, `extract_pipeline_generation_data/`, `extract_pipeline_validation_data/`, `get_workflow_executions_tracking/`
+- `GET /internal/attack_discovery/default_esql_query` (`server/routes/get/default_esql_query/`)
+- `@kbn/discoveries` `impl/lib/build_default_esql_query/` — default ES|QL query generation
+- `common/step_types/` — `esql` mode in `default_alert_retrieval_mode` enum
+- Bundled YAML: `attack_discovery_esql_example.workflow.yaml`
+- UI: `use_fetch_default_esql_query/` hook
+- `server/lib/schedules/` — schedule data client, workflow executor, constants
+- `server/lib/helpers/get_space_id/`
+
+**Review objectives**:
+- [G5] All routes use `snake_case` in request/response bodies and URL parameters
+- [G7] One function per file with unit tests
+- [G8] Pure functions where possible
+- [G11] Resilient against failures
+- [G12] Users can recover from failures without contacting support
+- [S7] Tracing failures via execution UUID in logs
+- [S8] Routes throw when FF is disabled
+- [S9] Routes execute in context of authenticated user, not super user
+- [S11] No privilege escalation possible from routes
+- [S12] RBAC has same semantics as existing Attack Discovery RBAC
+- [S13] ES clients execute in context of authenticated user
+- [S23] ESQL mode is correct when FF is ON
+
+**Review checklist**:
+- [ ] Every route handler checks `attackDiscoveryWorkflowsEnabled` and returns 404/403 when OFF
+- [ ] Route security config uses `requiredPrivileges` matching existing AD RBAC
+- [ ] `request.body` / `response.body` field names are all `snake_case`
+- [ ] URL path parameters are all `snake_case`
+- [ ] ES client is obtained from `context.core.elasticsearch.client.asCurrentUser` (not `asInternalUser`)
+- [ ] `_generate` is async (returns `execution_uuid`, not discoveries)
+- [ ] `_validate` validates discoveries and persists them
+- [ ] Schedule routes do not expose schedules created by the legacy API (and vice versa)
+- [ ] Error responses include structured error information for UI recovery
+- [ ] Each route handler file has a corresponding `.test.ts`
+- [ ] ES|QL query generation produces valid ES|QL
+- [ ] Default ES|QL query route returns expected format
+- [ ] ESQL mode retrieves alerts correctly via workflow step
+- [ ] Example ESQL workflow YAML is valid and functional
+
+---
+
+### PR 4: Orchestration Pipeline + Event Logging + Pre-Execution Validation
+
+**Goal**: Wire up the 3-phase orchestrated pipeline (retrieve -> generate -> validate) with full observability.
+
+<details>
+<summary><strong>Commit Message</strong></summary>
+
+## [Security Solution] [Attack Discovery] Wire up orchestrated pipeline with event logging and pre-execution validation
+
+This PR wires up the three-phase orchestrated pipeline that replaces the monolithic generation endpoint. Each generation run is assigned a unique `executionUuid` that appears in server logs, event log entries, EBT telemetry, and the API response — enabling end-to-end tracing.
+
+```yaml
+feature_flags.overrides:
+  securitySolution.attackDiscoveryWorkflowsEnabled: true
+```
+
+### Execution Flow
+
+```mermaid
+flowchart LR
+    UI["UI / Scheduler"] --> PRE["Pre-Flight\n(resolve IDs,\nverify integrity,\nvalidate)"]
+    PRE --> R["Phase 1\nAlert Retrieval"]
+    R --> G["Phase 2\nGeneration\n(LangGraph)"]
+    G --> V["Phase 3\nValidation +\nPersistence"]
+    V --> OBS["Observability\n(logs, event log,\nEBT, Workflows UI)"]
+```
+
+### Orchestration
+
+`executeOrchestratorWorkflow` composes three sequential workflow executions:
+
+1. **Alert Retrieval**: Runs the configured retrieval workflow (default DSL, ES|QL, or custom)
+2. **Generation**: Runs the generation workflow with LangGraph, emitting `generation-started`/`generation-succeeded`/`generation-failed` events to the Elasticsearch event log
+3. **Validation + Persistence**: Validates discoveries (hallucination detection, deduplication) and persists to the Attack Discovery index
+
+Each phase failure is caught, logged with the execution UUID, and reported in the execution summary.
+
+### Event Logging
+
+| Event | When | Key Fields |
+|-------|------|------------|
+| `generation-started` | Pipeline begins | `execution_uuid`, `alerts_context_count` |
+| `generation-succeeded` | Pipeline completes | `execution_uuid`, `duration_ns`, `discoveries_count` |
+| `generation-failed` | Pipeline fails | `execution_uuid`, `error_reason` |
+
+Events are written to `.kibana-event-log-*` and queryable via `GET /api/attack_discovery/generations`.
+
+### Pre-Execution Validation
+
+Before the pipeline starts, concurrent checks validate all preconditions:
+
+| Check | Severity | Behavior |
+|-------|----------|----------|
+| WorkflowsManagement API available | Critical | Aborts pipeline |
+| Default workflow IDs resolvable | Critical | Aborts pipeline |
+| Alerts index exists | Warning | Logs warning, continues |
+| Connector accessible | Warning | Logs warning, continues |
+
+### Observability
+
+- **Traced logger**: All log messages prefixed with `[execution: {uuid}]` for single-execution filtering
+- **INFO summary**: Logged after every run with per-step status, timing, and Workflows app links
+- **DEBUG health checks**: Lazy-evaluated precondition logging before each step (zero cost when off)
+
+</details>
+
+**Scope**:
+- Orchestration logic in `@kbn/discoveries`:
+  - `impl/attack_discovery/generation/` — orchestrator, alert retrieval invocation, generation workflow, validation workflow
+  - `impl/attack_discovery/generation/verify_workflow_integrity/` — SHA-256 hash comparison, self-healing gateway
+- Event logging:
+  - `impl/attack_discovery/persistence/event_logging/` — `writeAttackDiscoveryEvent`, event action constants, duration helpers
+  - Generate step event emission (`generation-started`, `generation-succeeded`, `generation-failed`)
+- Pre-execution validation:
+  - `validate_pre_execution/` — concurrent checks (API availability, default workflow IDs, alerts index, connector)
+- Traced logger:
+  - `impl/lib/create_traced_logger/` — `[execution: {uuid}]` prefix
+- Health checks:
+  - `server/lib/startup_health_check/`
+  - `impl/lib/log_health_check/` — per-step precondition logging
+- Execution summary:
+  - INFO-level orchestration summary with per-step status, timing, workflow links
+
+**Review objectives**:
+- [G11] Resilient against failures (pre-execution validation catches misconfigurations before pipeline starts)
+- [G12] Users can recover (clear error messages, self-healing)
+- [S5] Self-healing for damaged/missing workflows
+- [S7] Tracing via execution UUID in all log levels
+- [S17] Self-healing works in default and non-default spaces when workflows manually modified
+- [S18] Self-healing works when workflows manually deleted
+- [S19] Self-healing works when workflows manually disabled
+- [S21] Correctness of new event log entries
+
+**Review checklist**:
+- [ ] `executeOrchestratorWorkflow` composes retrieval -> generation -> validation phases
+- [ ] Each phase failure is caught and logged with execution UUID
+- [ ] `verifyWorkflowIntegrity` computes SHA-256, compares against bundled hashes, repairs if needed
+- [ ] Repair emits `workflow_modified` telemetry per repaired workflow
+- [ ] Repair failure aborts pipeline with `generation-failed` event
+- [ ] Pre-execution validation runs all checks concurrently
+- [ ] Critical issues abort; warnings allow continuation
+- [ ] Event log entries match the schema documented in README.md
+- [ ] Traced logger uses lazy evaluation: `logger.debug(() => ...)` not `logger.debug(...)`
+- [ ] Startup health check runs in `plugin.start()` and logs result
+- [ ] INFO summary logged after every orchestration run (success or failure)
+
+---
+
+### PR 5: Telemetry (EBT Events)
+
+**Goal**: Add fleet-wide telemetry for misconfigurations, step failures, schedule actions, and UI interactions.
+
+<details>
+<summary><strong>Commit Message</strong></summary>
+
+## [Security Solution] [Attack Discovery] Add EBT telemetry for workflow execution
+
+This PR adds Event-Based Telemetry (EBT) events for the Attack Discovery Workflows feature, providing fleet-wide visibility into execution outcomes, configuration problems, and UI engagement.
+
+All new EBT fields use `snake_case`. Existing telemetry events (`attack_discovery_success`, `attack_discovery_error`) are augmented with workflow-specific fields but their existing camelCase fields are retained as-is to avoid breaking the shared schema with `elastic_assistant`.
+
+### Server-Side Events
+
+| Event | Purpose | Key Fields |
+|-------|---------|------------|
+| `attack_discovery_misconfiguration` | Configuration problems (missing index, bad connector, etc.) | `misconfiguration_type`, `space_id`, `workflow_id` |
+| `attack_discovery_step_failure` | Per-step pipeline failures | `step`, `error_category`, `duration_ms`, `execution_uuid` |
+| `attack_discovery_schedule_action` | Schedule lifecycle operations | `action`, `has_actions`, `interval` |
+
+Events from the workflows path are distinguishable via `execution_mode: 'workflow'` on the shared `attack_discovery_success`/`attack_discovery_error` event types (absent on legacy).
+
+### Client-Side Events
+
+| Event | Purpose |
+|-------|---------|
+| `Attack Discovery Settings Saved` | Captures retrieval mode, workflow count, validation choices |
+| `Attack Discovery Generation Started` | Distinguishes workflow vs legacy execution mode |
+| `Attack Discovery Edit With AI Clicked` | Tracks AI-assisted ES\|QL editing usage |
+| `Attack Discovery Pipeline Step Inspected` | Tracks execution monitoring engagement |
+| _(+ 16 more settings/schedule/execution events)_ | Full list in client-side telemetry README |
+
+All events avoid collecting user-defined names, query content, alert data, or user identifiers. Only anonymous metadata (counts, modes, boolean flags, enum values) is captured.
+
+</details>
+
+**Scope**:
+- `@kbn/discoveries` telemetry:
+  - `impl/lib/telemetry/` — `report_step_failure/`, `report_misconfiguration/`, `report_schedule_action/`
+- `security_solution` telemetry:
+  - `public/common/lib/telemetry/events/attack_discovery/` — EBT event definitions, types, README
+  - `public/common/lib/telemetry/events/telemetry_events.ts` — registration
+  - `public/common/lib/telemetry/types.ts` — type extensions
+
+**Review objectives**:
+- [G6] All new telemetry event definitions use `snake_case` (existing camelCase not refactored)
+- [G10] No accidental artifacts
+
+**Review checklist**:
+- [ ] `attack_discovery_misconfiguration` event fields are `snake_case`
+- [ ] `attack_discovery_step_failure` event fields are `snake_case`
+- [ ] `attack_discovery_schedule_action` event fields are `snake_case`
+- [ ] Existing telemetry events are NOT modified
+- [ ] Telemetry README accurately documents all new events
+- [ ] Events include `execution_uuid` for correlation
+- [ ] Client-side events capture only anonymous metadata (no PII, query content, or alert data)
+
+---
+
+### PR 6: UI — Workflow Configuration (Settings Flyout)
+
+**Goal**: Add workflow configuration UI to the Attack Discovery settings flyout.
+
+<details>
+<summary><strong>Commit Message</strong></summary>
+
+## [Security Solution] [Attack Discovery] Add workflow configuration UI to settings flyout
+
+This PR adds workflow configuration options to the Attack Discovery settings flyout, enabling users to customize alert retrieval, select custom workflows, edit retrieval queries with AI, and manage generation schedules — all when the feature flag is enabled. When the flag is OFF, the settings flyout renders the existing experience unchanged.
+
+```yaml
+feature_flags.overrides:
+  securitySolution.attackDiscoveryWorkflowsEnabled: true
+```
+
+### New Settings
+
+- **Alert retrieval mode**: query DSL (default), ES|QL, or custom workflow — with a query builder, date range picker, and alert preview panel
+- **Custom workflow picker**: select custom alert retrieval and validation workflows with async existence/enabled validation
+- **Edit with AI**: opens the Agent Builder sidebar with the user's current ES|QL query as an attachment; changes sync back in real time via a dual-path model (explicit tool call + attachment fallback)
+- **Validation panel**: select a custom validation workflow or use the default; async checks display errors (red) vs warnings (yellow)
+
+### Schedule Management
+
+Full schedule lifecycle via the settings flyout:
+- **Create flyout**: name, interval, connector, notification actions
+- **Details flyout**: view/edit existing schedules
+- **Schedules table**: list, enable, disable, delete schedules
+
+### Async Validation
+
+When workflow settings change, the UI performs async runtime checks:
+- Verifies selected custom workflows exist and are enabled
+- Displays errors (configuration will fail) vs warnings (configuration may have issues) in the validation callout
+
+</details>
+
+**Scope**:
+- `security_solution/public/attack_discovery/pages/settings_flyout/`:
+  - `workflow_configuration/` — main configuration panel
+  - `workflow_configuration/edit_with_ai/` — AI-assisted workflow editing
+  - `workflow_configuration/local_storage/` — persistent user preferences
+  - `workflow_configuration/validation_panel/` — async workflow validation (existence, enabled checks)
+  - `alert_selection/` — query-based alert filtering with preview
+    - `alert_selection_query/`, `alert_selection_range/`, `preview_tab/`
+    - `get_alert_summary_esql_query/`, `get_alerts_preview_esql_query/`
+    - `get_alert_summary_lens_attributes/`
+    - `connector_field/`
+  - `workflow_picker/` — workflow selection UI
+  - `workflow_option_renderers/` — custom option rendering
+  - Schedule management:
+    - `schedule/create_flyout/`, `schedule/details_flyout/`, `schedule/schedules_table/`, `schedule/edit_form/`
+- Hooks: `use_schedule_view`, `use_settings_view`, `use_tabs_view`
+
+**Review objectives**:
+- [S3] Edit with AI feature/skill
+- [S6] Workflow execution status monitoring (settings side)
+- [S22] Query builder mode correct when FF off
+- [S22b] Query builder mode correct when FF on
+- [S26] Anonymization works when FF off
+- [S27] Anonymization works when FF on
+
+**Review checklist**:
+- [ ] Settings flyout conditionally renders workflow configuration only when FF is ON
+- [ ] When FF is OFF, existing settings UI is unchanged
+- [ ] Alert selection query builder works in both FF states
+- [ ] Workflow picker validates selected workflows asynchronously
+- [ ] Validation panel shows errors (red) vs warnings (yellow) correctly
+- [ ] Edit with AI uses the Agent Builder skill correctly
+- [ ] Schedule CRUD flows work end-to-end via settings UI
+- [ ] Custom validation workflows are selectable
+- [ ] Custom alert retrieval workflows are selectable
+- [ ] All new components have unit tests
+
+---
+
+### PR 7: UI — Workflow Execution Monitoring + Details Flyout
+
+**Goal**: Add real-time workflow execution monitoring and detailed inspection UI.
+
+<details>
+<summary><strong>Commit Message</strong></summary>
+
+## [Security Solution] [Attack Discovery] Add workflow execution monitoring and details flyout
+
+This PR adds real-time workflow execution monitoring to the Attack Discovery UI, including a live progress display, pipeline data cards, per-step inspection, failure classification, and AI-assisted troubleshooting.
+
+When the feature flag is OFF, the loading callout renders the legacy experience unchanged.
+
+```yaml
+feature_flags.overrides:
+  securitySolution.attackDiscoveryWorkflowsEnabled: true
+```
+
+### Execution Monitoring
+
+- **Loading callout**: Live timer showing elapsed time during generation, with pipeline data cards displaying alert and discovery counts as they arrive
+- **Loading messages**: Contextual success messages composed from pipeline data
+
+### Execution Details Flyout
+
+- **Per-step inspection**: View inputs, outputs, status, and timing for each pipeline step (alert retrieval, generation, validation)
+- **Step data modal**: Serialized step input/output inspection with alert summary
+- **Failure classification**: Categorizes errors into actionable categories (connector error, timeout, validation error, workflow error, unknown)
+- **Troubleshoot with AI**: Opens Agent Builder with diagnostic context pre-attached for AI-assisted root cause analysis
+- **Diagnostic report**: Environment context, error details, and workflow execution metadata
+
+### Workflow Links
+
+Links in the execution details flyout point to the specific workflow run in the Workflows app, matching the URLs logged in the server-side execution summary.
+
+### Generation History
+
+Generation history view showing past executions with status, timing, and discovery counts.
+
+</details>
+
+**Scope**:
+- `pages/hooks/use_workflow_execution_details/` — execution tracking hook system
+  - `build_stub_workflow_execution/` (with timing, status, output helpers)
+  - `get_step_status_from_events/`
+  - `helpers/` (aggregation, lookup, step execution building)
+- `pages/hooks/use_pipeline_data/` — pipeline data processing
+- `pages/hooks/use_workflow_tracking/` — workflow event tracking
+- `pages/loading_callout/` — loading state with live feedback
+  - `live_timer/` — elapsed time display
+  - `pipeline_data_cards/` — pipeline metrics visualization
+  - `loading_messages/` — success message composition
+- `pages/loading_callout/workflow_execution_details_flyout/` — detailed inspection
+  - `diagnostic_report/` — diagnostic data display
+  - `inspect_diagnostic_report_flyout/` — nested inspection
+  - `failure_actions/` — recovery action buttons
+  - `troubleshoot_with_ai/` — AI-assisted troubleshooting
+  - `classify_error_category/`, `classify_failure/`
+  - `get_environment_context/`, `sanitize_error_message/`
+  - `group_steps_by_phase/`
+- `pages/loading_callout/step_data_modal/` — step execution inspection
+  - `workflow_alerts_summary_line/`
+- `pages/results/history/` — generation history
+- `pages/results/attack_discovery_panel/panel_header/primary_interactions/badges/shared_badge/`
+
+**Review objectives**:
+- [S4] Troubleshoot with AI skill
+- [S6] Workflow execution status monitoring
+- [S20] Troubleshoot with AI feature works
+- [S25] Inspect features of workflow execution details are correct
+- [S28] Links in workflow execution details flyout go to the workflow that was run
+
+**Review checklist**:
+- [ ] Execution monitoring only appears when FF is ON
+- [ ] When FF is OFF, loading callout renders the legacy experience
+- [ ] Workflow execution details flyout links point to correct workflow run URLs
+- [ ] Step data modal correctly serializes and displays step inputs/outputs
+- [ ] Failure classification produces actionable categories
+- [ ] Troubleshoot with AI correctly invokes the Agent Builder conversation
+- [ ] Diagnostic report includes all relevant environment context
+- [ ] Pipeline data cards show correct alert/discovery counts
+- [ ] Live timer updates in real-time during execution
+- [ ] All new hooks and components have unit tests
+
+---
+
+### PR 8: Skills (Edit with AI + Troubleshoot with AI)
+
+**Goal**: Register Agent Builder skills for workflow editing and troubleshooting.
+
+<details>
+<summary><strong>Commit Message</strong></summary>
+
+## [Security Solution] [Attack Discovery] Register Agent Builder skills for workflow editing and troubleshooting
+
+This PR registers two Agent Builder skills that enhance the Attack Discovery workflow experience:
+
+```yaml
+feature_flags.overrides:
+  securitySolution.attackDiscoveryWorkflowsEnabled: true
+```
+
+### Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `alert-retrieval-builder` | Generates custom alert retrieval workflow YAML via an LLM agent. The user describes their alert selection criteria in natural language, and the skill produces a valid workflow YAML that can be used as a custom retrieval workflow. |
+| `workflow-troubleshooting` | Diagnoses workflow execution failures using diagnostic context. When a generation fails, the user can click "Troubleshoot with AI" in the execution details flyout, which opens Agent Builder with a diagnostic report pre-attached (environment context, error details, step inputs/outputs). |
+
+### Implementation
+
+- `server/skills/register_skills.ts` — conditional registration (FF gated)
+- `server/skills/alert_retrieval_builder_skill.ts` — alert retrieval skill definition with tool implementations
+- `server/skills/workflow_troubleshooting_skill.ts` — troubleshooting skill definition
+- `server/skills/tools/` — skill tool implementations
+- `server/agent_builder/attachments/diagnostic_report/` — diagnostic attachment for troubleshooting context
+
+Skills only register when the feature flag is ON. Registration failures are handled gracefully.
+
+</details>
+
+**Scope**:
+- `server/skills/register_skills.ts` — skill registration
+- `server/skills/alert_retrieval_builder_skill.ts` — alert retrieval workflow editing skill
+- `server/skills/workflow_troubleshooting_skill.ts` — troubleshooting skill
+- `server/skills/tools/` — skill tool implementations
+- `server/agent_builder/attachments/diagnostic_report/` — diagnostic attachment for troubleshooting
+
+**Review objectives**:
+- [S3] Edit with AI feature/skill
+- [S4] Troubleshoot with AI skill
+- [S20] Troubleshoot with AI feature works
+
+**Review checklist**:
+- [ ] Skills only register when FF is ON
+- [ ] Skills have correct permission requirements
+- [ ] Alert retrieval builder produces valid workflow YAML
+- [ ] Troubleshooting skill has access to diagnostic context
+- [ ] Skill registration failures are handled gracefully
+
+---
+
+### PR 9: Self-Healing + Workflow Integrity Verification
+
+**Goal**: Implement automatic detection and repair of damaged/missing/disabled workflows.
+
+<details>
+<summary><strong>Commit Message</strong></summary>
+
+## [Security Solution] [Attack Discovery] Add self-healing workflow integrity verification
+
+This PR implements automatic detection and repair of the 3 required default workflows (alert retrieval, generation, validation). Before each generation run, the system verifies workflow integrity via SHA-256 hash comparison against bundled definitions. If any workflow has been deleted or modified, it is automatically restored. If restoration fails, the pipeline aborts with a clear error.
+
+### Algorithm
+
+Runs in parallel for all 3 required workflows:
+
+1. Fetch each workflow from Elasticsearch via the Workflows Management API
+2. **If missing**: re-create from the bundled YAML definition
+3. **If present**: compute SHA-256 hash and compare against the bundled hash
+4. **If hashes match**: no action (`all_intact`)
+5. **If hashes differ**: overwrite with bundled YAML (`repaired`)
+6. **If restore fails**: record as `unrepairableError`
+
+### Outcomes
+
+| Status | Meaning | Pipeline |
+|--------|---------|----------|
+| `all_intact` | All 3 workflows match bundled definitions | Continues |
+| `repaired` | One or more workflows were restored; `workflow_modified` telemetry emitted per workflow | Continues |
+| `repair_failed` | One or more workflows could not be restored | **Aborted** — `generation-failed` event with error reason |
+
+### Observability
+
+| Scenario | Log Level | Telemetry |
+|----------|-----------|-----------|
+| All intact | DEBUG | None |
+| Modified, restoration succeeds | INFO | `workflow_modified` per workflow |
+| Missing, re-creation succeeds | ERROR (detection) + INFO (success) | `workflow_modified` per workflow |
+| Repair fails | ERROR | None (execution aborted) |
+
+The bundled YAML hash utility reads the 3 required YAML files from disk at first access, computes SHA-256 hashes (Node.js `crypto`), and caches results (bundled files are immutable at runtime).
+
+</details>
+
+**Scope**:
+- `server/lib/workflow_initialization/` — service interface + implementation
+- `server/lib/workflow_initialization/verify_and_repair_workflows/` — verify-and-repair logic
+- `@kbn/discoveries` `impl/attack_discovery/generation/verify_workflow_integrity/` — execution integration
+- `server/workflows/helpers/get_bundled_yaml_entries/` — bundled YAML hash utility (SHA-256)
+
+**Review objectives**:
+- [S5] Self-healing for damaged/missing workflows
+- [S17] Self-healing works in default and non-default spaces when workflows manually modified
+- [S18] Self-healing works when workflows manually deleted
+- [S19] Self-healing works when workflows manually disabled
+- [G11] Resilient against failures
+- [G12] Users can recover without contacting support
+
+**Review checklist**:
+- [ ] SHA-256 hash comparison against bundled YAML is correct
+- [ ] Missing workflows are re-created from bundled definitions
+- [ ] Modified workflows are overwritten with bundled definitions
+- [ ] Disabled workflows are re-enabled (or handled appropriately)
+- [ ] Repair failures are logged and abort the pipeline cleanly
+- [ ] `workflow_modified` telemetry emitted per repaired workflow
+- [ ] Self-healing runs in the correct space context
+- [ ] Hash cache is invalidated appropriately (bundled files are immutable at runtime)
+- [ ] Concurrent repair attempts are safe (no race conditions)
+
+---
+
+### PR 10: Schedule Integration (Workflows-Based Scheduling)
+
+**Goal**: Integrate workflow-based generation with the Alerting Framework scheduler.
+
+<details>
+<summary><strong>Commit Message</strong></summary>
+
+## [Security Solution] [Attack Discovery] Integrate workflow-based generation with alerting-framework scheduling
+
+This PR connects the workflow-based generation pipeline to the Alerting Framework scheduler, completing the hybrid scheduling architecture. The Alerting Framework owns scheduling, alert persistence, and action execution (with full throttling/frequency support). The Workflows engine owns only the generation pipeline.
+
+### Hybrid Architecture
+
+```
+┌───────────────────────────────┐     ┌────────────────────────────────┐
+│  Alerting Framework           │     │  Workflows Engine               │
+│  - Scheduling (Task Manager)  │     │  - Generation pipeline          │
+│  - Alert persistence (AAD)    │ ──► │  - Alert retrieval              │
+│  - Action execution           │     │  - LangGraph generation         │
+│  - Throttling/frequency       │     │  - Validation + persistence     │
+└───────────────────────────────┘     └────────────────────────────────┘
+```
+
+### Changes
+
+- **Workflow executor** (`server/lib/schedules/workflow_executor/`): Delegates to the orchestration pipeline (`executeGenerationWorkflow`) instead of inline generation logic. Runs in the context of the authenticated user.
+- **Schedule data client** (`server/lib/schedules/create_schedule_data_client/`): Uses tag-based filtering to isolate internal schedules from public API schedules.
+- **`elastic_assistant` updates**: Schedule registration (`register_schedule/definition.ts`, `register_schedule/executor.ts`) updated to coexist with the workflow executor.
+- **`@kbn/attack-discovery-schedules-common` transforms**: Extended with `workflowConfig` support for schedule create/update operations.
+
+### Isolation
+
+The internal schedule API tags every schedule with `attack-discovery-schedule` and filters reads to only that tag. The public API applies no tags. This bidirectional isolation ensures:
+- FF OFF: legacy schedule users never see workflow-created schedules
+- FF ON: legacy schedule users still never see workflow-created schedules
+- Internal API users only see their own schedules
+
+</details>
+
+**Scope**:
+- `server/lib/schedules/workflow_executor/` — schedule executor using workflows
+- `server/lib/schedules/create_schedule_data_client/` — schedule data client
+- `elastic_assistant` schedule registration updates (`register_schedule/definition.ts`, `register_schedule/executor.ts`)
+- `@kbn/attack-discovery-schedules-common` transforms for workflow config
+
+**Review objectives**:
+- [S14] FF OFF: schedule API users do NOT see schedules created by new API
+- [S15] FF ON: schedule API users also do NOT see schedules created by new API
+- [S10] Workflows always execute in context of authenticated user
+- [G3] Existing schedule public APIs behave the same when FF is ON
+
+**Review checklist**:
+- [ ] Workflow executor invokes the orchestration pipeline (not the legacy graph)
+- [ ] Schedule data client correctly filters by source (legacy vs. workflows)
+- [ ] Authenticated user context is preserved through scheduled execution
+- [ ] Schedule actions (email, webhook, etc.) work through the alerting framework
+- [ ] Schedule CRUD operations are isolated between legacy and workflows APIs
+
+---
+
+## Cross-Cutting Review Objectives
+
+These objectives apply to ALL PRs in the stack:
+
+| ID | Objective | Applies to |
+|----|-----------|------------|
+| G1 | AD + schedules work when FF OFF | All PRs |
+| G2 | Defend insights unaffected | PR 1 |
+| G3 | Existing public APIs unchanged when FF ON | PR 1, 3, 10 |
+| G4 | All above true for serverless | All PRs |
+| G5 | New routes use `snake_case` | PR 3 |
+| G6 | New telemetry uses `snake_case` | PR 5 |
+| G7 | One function per file with tests | All PRs |
+| G8 | Pure functions, no side effects | All PRs |
+| G9 | No unnecessary mutation | All PRs |
+| G10 | No accidental artifacts | All PRs |
+| G11 | Resilient against failures | PR 3, 4, 9 |
+| G12 | Users can recover without support | PR 4, 7, 9 |
+| G13 | Platform changes are registrations only | PR 2 |
+
+| ID | Specific Item | PR |
+|----|--------------|-----|
+| S1 | Plugin lifecycle artifact creation | PR 2 |
+| S2 | Health checks | PR 4 |
+| S3 | Edit with AI | PR 6, 8 |
+| S4 | Troubleshoot with AI | PR 7, 8 |
+| S5 | Self-healing | PR 9 |
+| S6 | Execution status monitoring | PR 7 |
+| S7 | Tracing via execution UUID | PR 4 |
+| S8 | Routes throw when FF disabled | PR 3 |
+| S9 | Routes use authenticated user context | PR 3 |
+| S10 | Workflows use authenticated user context | PR 3, 10 |
+| S11 | No privilege escalation | PR 3 |
+| S12 | RBAC matches existing AD RBAC | PR 3 |
+| S13 | ES clients use authenticated user | PR 3 |
+| S14 | FF OFF: legacy schedules isolated | PR 10 |
+| S15 | FF ON: legacy schedules still isolated | PR 10 |
+| S16 | Alerts and Attacks Alignment not broken | All PRs |
+| S17 | Self-healing: modified workflows | PR 9 |
+| S18 | Self-healing: deleted workflows | PR 9 |
+| S19 | Self-healing: disabled workflows | PR 9 |
+| S20 | Troubleshoot with AI works | PR 7, 8 |
+| S21 | Event log entries correct | PR 4 |
+| S22 | Query builder correct when FF off | PR 6 |
+| S22b | Query builder correct when FF on | PR 6 |
+| S23 | ESQL mode correct when FF on | PR 3 |
+| S24 | Example run workflow correct | PR 2 |
+| S25 | Inspect features correct | PR 7 |
+| S26 | Anonymization correct when FF off | PR 6 |
+| S27 | Anonymization correct when FF on | PR 6 |
+| S28 | Flyout links go to correct workflow | PR 7 |
+
+---
+
+## Dependency Graph
+
+```
+PR 1 (Shared Packages + elastic_assistant Refactor)
+ ├── PR 2 (Plugin Scaffold + Step Registration)
+ │    ├── PR 3 (Internal API Routes + ES|QL Mode)
+ │    │    ├── PR 4 (Orchestration + Event Logging)
+ │    │    │    ├── PR 9 (Self-Healing)
+ │    │    │    └── PR 10 (Schedule Integration)
+ │    │    └── PR 8 (Skills)
+ │    └── PR 5 (Telemetry)
+ ├── PR 6 (UI: Workflow Configuration)
+ └── PR 7 (UI: Execution Monitoring)
+```
+
+**Parallelizable**:
+- PR 5, 6, 7 can be developed in parallel after PR 2
+- PR 8 can be developed in parallel after PR 3
+- PR 9 and PR 10 can be developed in parallel after PR 4
+
+---
+
+## Merge Strategy
+
+1. **PRs 1-2**: Safe for immediate merge to serverless — they add packages and a disabled-by-default plugin
+2. **PRs 3-5**: Safe once the plugin scaffold is merged — routes are gated by FF
+3. **PRs 6-7**: UI changes gated by FF — safe for merge after PR 2
+4. **PRs 8-10**: Specialized features — merge after their dependencies
+
+---
+
+## Risk Assessment
+
+| Risk | Mitigation | PRs |
+|------|-----------|-----|
+| Shared package extraction breaks existing behavior | PR 1 review focuses on import path changes only; all existing tests must pass | PR 1 |
+| Defend insights regression | Explicit test coverage for defend insights graphs | PR 1 |
+| New plugin side effects when FF OFF | Plugin setup/start gated by FF check; startup health check is defensive | PR 2 |
+| Route privilege escalation | All routes use `asCurrentUser`; RBAC matches existing AD privileges | PR 3 |
+| Self-healing race conditions | Verify-and-repair runs synchronously per request; concurrent requests are safe because repair is idempotent | PR 9 |
+| Schedule isolation leak | Schedule data client filters by source field; cross-API queries return empty | PR 10 |
+| Serverless differences | Workflows engine availability varies; pre-execution validation handles gracefully | PR 4 |

--- a/x-pack/solutions/security/plugins/discoveries/common/constants.d.ts
+++ b/x-pack/solutions/security/plugins/discoveries/common/constants.d.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export declare const DIAGNOSTIC_REPORT_ATTACHMENT_TYPE = 'diagnostic_report';

--- a/x-pack/solutions/security/plugins/discoveries/common/constants.ts
+++ b/x-pack/solutions/security/plugins/discoveries/common/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const DIAGNOSTIC_REPORT_ATTACHMENT_TYPE = 'diagnostic_report';

--- a/x-pack/solutions/security/plugins/discoveries/common/step_types/default_alert_retrieval_step.ts
+++ b/x-pack/solutions/security/plugins/discoveries/common/step_types/default_alert_retrieval_step.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { i18n } from '@kbn/i18n';
+import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+import { StepCategory } from '@kbn/workflows';
+
+import { AnonymizedAlertSchema, ApiConfigSchema } from './shared_schemas';
+
+/**
+ * Step type ID for the default alert retrieval step.
+ */
+export const DefaultAlertRetrievalStepTypeId = 'attack-discovery.defaultAlertRetrieval';
+
+const AnonymizationFieldSchema = z.object({
+  allowed: z.boolean().optional(),
+  anonymized: z.boolean().optional(),
+  field: z.string(),
+  id: z.string(),
+});
+
+/**
+ * Input schema for Default Alert Retrieval step.
+ */
+export const DefaultAlertRetrievalInputSchema = z.object({
+  alerts_index_pattern: z.string(),
+  anonymization_fields: z.array(AnonymizationFieldSchema),
+  api_config: ApiConfigSchema,
+  end: z.string().optional(),
+  esql_query: z.string().optional(),
+  filter: z.record(z.string(), z.unknown()).optional(),
+  replacements: z.record(z.string(), z.string()).optional(),
+  size: z.number().int(),
+  start: z.string().optional(),
+});
+
+/**
+ * Output schema for Default Alert Retrieval step.
+ */
+export const DefaultAlertRetrievalOutputSchema = z.object({
+  alerts: z.array(z.string()),
+  alerts_context_count: z.number().int(),
+  anonymized_alerts: z.array(AnonymizedAlertSchema).optional(),
+  api_config: ApiConfigSchema,
+  connector_name: z.string().optional(),
+  replacements: z.record(z.string(), z.string()),
+});
+
+/**
+ * Common step definition for Default Alert Retrieval step.
+ * This step retrieves and anonymizes alerts for Attack Discovery generation.
+ * Shared between server and public implementations.
+ */
+export const DefaultAlertRetrievalStepCommonDefinition: CommonStepDefinition<
+  typeof DefaultAlertRetrievalInputSchema,
+  typeof DefaultAlertRetrievalOutputSchema
+> = {
+  category: StepCategory.Elasticsearch,
+  description: i18n.translate('xpack.discoveries.workflowSteps.defaultAlertRetrieval.description', {
+    defaultMessage:
+      'Retrieve and anonymize security alerts from Elasticsearch for Attack Discovery generation',
+  }),
+  id: DefaultAlertRetrievalStepTypeId,
+  inputSchema: DefaultAlertRetrievalInputSchema,
+  label: i18n.translate('xpack.discoveries.workflowSteps.defaultAlertRetrieval.label', {
+    defaultMessage: 'Attack Discovery: Alert Retrieval',
+  }),
+  outputSchema: DefaultAlertRetrievalOutputSchema,
+};

--- a/x-pack/solutions/security/plugins/discoveries/common/step_types/default_validation_step.ts
+++ b/x-pack/solutions/security/plugins/discoveries/common/step_types/default_validation_step.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { i18n } from '@kbn/i18n';
+import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+import { StepCategory } from '@kbn/workflows';
+
+import { AnonymizedAlertSchema, ApiConfigSchema, AttackDiscoverySchema } from './shared_schemas';
+
+/**
+ * Step type ID for the default validation step.
+ */
+export const DefaultValidationStepTypeId = 'attack-discovery.defaultValidation';
+
+/**
+ * Input schema for Default Validation step.
+ */
+export const DefaultValidationInputSchema = z.object({
+  alerts_context_count: z.number().int().optional(),
+  alerts_index_pattern: z.string().optional().default('.alerts-security.alerts-*'),
+  anonymized_alerts: z.array(AnonymizedAlertSchema).optional(),
+  api_config: ApiConfigSchema,
+  attack_discoveries: z.array(AttackDiscoverySchema),
+  connector_name: z.string().optional(),
+  enable_field_rendering: z.boolean().optional().default(true),
+  generation_uuid: z.string(),
+  replacements: z.record(z.string(), z.string()).optional(),
+  with_replacements: z.boolean().optional().default(false),
+});
+
+/**
+ * Output schema for Default Validation step.
+ */
+export const DefaultValidationOutputSchema = z.object({
+  filter_reason: z.string().optional(),
+  filtered_count: z.number().int(),
+  validated_discoveries: z.array(z.unknown()),
+});
+
+/**
+ * Common step definition for Default Validation step.
+ * This step performs hallucination detection and deduplication on generated Attack Discoveries.
+ * Shared between server and public implementations.
+ */
+export const DefaultValidationStepCommonDefinition: CommonStepDefinition<
+  typeof DefaultValidationInputSchema,
+  typeof DefaultValidationOutputSchema
+> = {
+  category: StepCategory.Kibana,
+  description: i18n.translate('xpack.discoveries.workflowSteps.defaultValidation.description', {
+    defaultMessage:
+      'Detect hallucinated alert references and deduplicate generated Attack Discoveries',
+  }),
+  id: DefaultValidationStepTypeId,
+  inputSchema: DefaultValidationInputSchema,
+  label: i18n.translate('xpack.discoveries.workflowSteps.defaultValidation.label', {
+    defaultMessage: 'Attack Discovery: Validation',
+  }),
+  outputSchema: DefaultValidationOutputSchema,
+};

--- a/x-pack/solutions/security/plugins/discoveries/common/step_types/generate_step.ts
+++ b/x-pack/solutions/security/plugins/discoveries/common/step_types/generate_step.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { i18n } from '@kbn/i18n';
+import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+import { StepCategory } from '@kbn/workflows';
+
+import { ApiConfigSchema, AttackDiscoverySchema } from './shared_schemas';
+
+/**
+ * Step type ID for the generate step.
+ */
+export const GenerateStepTypeId = 'attack-discovery.generate';
+
+/**
+ * Input schema for Generate step.
+ */
+export const GenerateStepInputSchema = z.object({
+  /**
+   * Optional free-form text appended to the LLM generation prompt.
+   * Provides extra context, constraints, or focus areas for the model.
+   */
+  additional_context: z.string().optional(),
+  /**
+   * Pre-retrieved alerts in a format compatible with the prompt
+   */
+  alerts: z.array(z.string()).min(1),
+  /**
+   * Connector configuration
+   */
+  api_config: ApiConfigSchema,
+  /**
+   * Anonymization replacements map
+   */
+  replacements: z.record(z.string(), z.string()).optional(),
+  /**
+   * Maximum number of discoveries to generate
+   */
+  size: z.number().int().optional().default(10),
+});
+
+/**
+ * Output schema for Generate step.
+ */
+export const GenerateStepOutputSchema = z.object({
+  /**
+   * Generated attack discoveries (null if none generated)
+   */
+  attack_discoveries: z.array(AttackDiscoverySchema).nullable(),
+  /**
+   * Unique identifier for this generation execution
+   */
+  execution_uuid: z.string().uuid(),
+  /**
+   * Updated anonymization replacements map
+   */
+  replacements: z.record(z.string(), z.string()),
+});
+
+/**
+ * Common step definition for Generate step.
+ * This step generates attack discoveries from pre-retrieved alerts.
+ * Shared between server and public implementations.
+ */
+export const GenerateStepCommonDefinition: CommonStepDefinition<
+  typeof GenerateStepInputSchema,
+  typeof GenerateStepOutputSchema
+> = {
+  category: StepCategory.Ai,
+  description: i18n.translate('xpack.discoveries.workflowSteps.generate.description', {
+    defaultMessage: 'Generate attack discoveries from alerts using AI analysis',
+  }),
+  id: GenerateStepTypeId,
+  inputSchema: GenerateStepInputSchema,
+  label: i18n.translate('xpack.discoveries.workflowSteps.generate.label', {
+    defaultMessage: 'Attack Discovery: Generate',
+  }),
+  outputSchema: GenerateStepOutputSchema,
+};

--- a/x-pack/solutions/security/plugins/discoveries/common/step_types/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/common/step_types/index.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  DefaultAlertRetrievalStepCommonDefinition,
+  DefaultAlertRetrievalStepTypeId,
+} from './default_alert_retrieval_step';
+
+export {
+  DefaultValidationStepCommonDefinition,
+  DefaultValidationStepTypeId,
+} from './default_validation_step';
+
+export { GenerateStepCommonDefinition, GenerateStepTypeId } from './generate_step';
+
+export {
+  PersistDiscoveriesStepCommonDefinition,
+  PersistDiscoveriesStepTypeId,
+} from './persist_discoveries_step';
+
+export { RunStepCommonDefinition, RunStepTypeId } from './run_step';
+
+export { AnonymizedAlertSchema, ApiConfigSchema, AttackDiscoverySchema } from './shared_schemas';
+
+export type { AnonymizedAlert, ApiConfig, AttackDiscovery } from './shared_schemas';

--- a/x-pack/solutions/security/plugins/discoveries/common/step_types/persist_discoveries_step.ts
+++ b/x-pack/solutions/security/plugins/discoveries/common/step_types/persist_discoveries_step.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { i18n } from '@kbn/i18n';
+import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+import { StepCategory } from '@kbn/workflows';
+
+import { AnonymizedAlertSchema, ApiConfigSchema, AttackDiscoverySchema } from './shared_schemas';
+
+export const PersistDiscoveriesStepTypeId = 'attack-discovery.persistDiscoveries';
+
+export const PersistDiscoveriesInputSchema = z.object({
+  alerts_context_count: z.number().int(),
+  anonymized_alerts: z.array(AnonymizedAlertSchema),
+  api_config: ApiConfigSchema,
+  attack_discoveries: z.array(AttackDiscoverySchema),
+  connector_name: z.string().optional(),
+  enable_field_rendering: z.boolean().optional().default(true),
+  generation_uuid: z.string(),
+  replacements: z.record(z.string(), z.string()).optional(),
+  with_replacements: z.boolean().optional().default(false),
+});
+
+export const PersistDiscoveriesOutputSchema = z.object({
+  duplicates_dropped_count: z.number().int(),
+  persisted_discoveries: z.array(z.unknown()),
+});
+
+export const PersistDiscoveriesStepCommonDefinition: CommonStepDefinition<
+  typeof PersistDiscoveriesInputSchema,
+  typeof PersistDiscoveriesOutputSchema
+> = {
+  category: StepCategory.Kibana,
+  description: i18n.translate('xpack.discoveries.workflowSteps.persistDiscoveries.description', {
+    defaultMessage:
+      'Write validated Attack Discoveries as alerts to the Attack Discovery alerts index with deduplication',
+  }),
+  id: PersistDiscoveriesStepTypeId,
+  inputSchema: PersistDiscoveriesInputSchema,
+  label: i18n.translate('xpack.discoveries.workflowSteps.persistDiscoveries.label', {
+    defaultMessage: 'Attack Discovery: Persist Discoveries',
+  }),
+  outputSchema: PersistDiscoveriesOutputSchema,
+};

--- a/x-pack/solutions/security/plugins/discoveries/common/step_types/run_step.ts
+++ b/x-pack/solutions/security/plugins/discoveries/common/step_types/run_step.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { i18n } from '@kbn/i18n';
+import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+import { StepCategory } from '@kbn/workflows';
+
+import { AttackDiscoverySchema } from './shared_schemas';
+
+/**
+ * Step type ID for the run step.
+ */
+export const RunStepTypeId = 'attack-discovery.run';
+
+/**
+ * Input schema for the Run step.
+ *
+ * Only `connector_id` is required. All other fields are optional,
+ * allowing workflow authors to invoke Attack Discovery with minimal
+ * configuration.
+ */
+export const RunStepInputSchema = z.object({
+  additional_context: z.string().optional(),
+  alert_retrieval_mode: z
+    .enum(['custom_query', 'disabled', 'esql', 'provided'])
+    .optional()
+    .default('custom_query'),
+  alert_retrieval_workflow_ids: z.array(z.string()).optional().default([]),
+  alerts: z.array(z.string()).optional(),
+  connector_id: z.string(),
+  end: z.string().optional(),
+  esql_query: z.string().optional(),
+  filter: z.record(z.string(), z.unknown()).optional(),
+  mode: z.enum(['async', 'sync']).optional().default('sync'),
+  size: z.number().int().optional(),
+  start: z.string().optional(),
+  validation_workflow_id: z.string().optional().default(''),
+});
+
+/**
+ * Output schema for the Run step (sync mode).
+ *
+ * Sync mode returns discoveries inline. Async mode returns only
+ * `execution_uuid`. The `replacements` map is explicitly excluded
+ * from both modes for security.
+ */
+export const RunStepOutputSchema = z.object({
+  alerts_context_count: z.number().int().optional(),
+  attack_discoveries: z.array(AttackDiscoverySchema).nullable().optional(),
+  discovery_count: z.number().int().optional(),
+  execution_uuid: z.string(),
+});
+
+/**
+ * Common step definition for the Run step.
+ * High-level entry point that orchestrates alert retrieval, generation,
+ * and validation in a single step.
+ */
+export const RunStepCommonDefinition: CommonStepDefinition<
+  typeof RunStepInputSchema,
+  typeof RunStepOutputSchema
+> = {
+  category: StepCategory.Ai,
+  description: i18n.translate('xpack.discoveries.workflowSteps.run.description', {
+    defaultMessage:
+      'Run the full Attack Discovery pipeline: retrieve alerts, generate discoveries, and validate results',
+  }),
+  id: RunStepTypeId,
+  inputSchema: RunStepInputSchema,
+  label: i18n.translate('xpack.discoveries.workflowSteps.run.label', {
+    defaultMessage: 'Attack Discovery: Run',
+  }),
+  outputSchema: RunStepOutputSchema,
+};

--- a/x-pack/solutions/security/plugins/discoveries/common/step_types/shared_schemas.ts
+++ b/x-pack/solutions/security/plugins/discoveries/common/step_types/shared_schemas.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+
+/**
+ * Reusable schema for anonymized alert documents passed between workflow steps.
+ */
+export const AnonymizedAlertSchema = z.object({
+  id: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()),
+  page_content: z.string(),
+});
+
+export type AnonymizedAlert = z.infer<typeof AnonymizedAlertSchema>;
+
+/**
+ * Reusable schema for connector / LLM configuration passed between workflow steps.
+ */
+export const ApiConfigSchema = z.object({
+  action_type_id: z.string().optional(),
+  connector_id: z.string(),
+  default_system_prompt_id: z.string().optional(),
+  model: z.string().optional(),
+  provider: z.enum(['OpenAI', 'Azure OpenAI', 'Other']).optional(),
+});
+
+export type ApiConfig = z.infer<typeof ApiConfigSchema>;
+
+/**
+ * Reusable schema for a single generated attack discovery.
+ */
+export const AttackDiscoverySchema = z.object({
+  alert_ids: z.array(z.string()),
+  details_markdown: z.string(),
+  entity_summary_markdown: z.string().optional(),
+  id: z.string().optional(),
+  mitre_attack_tactics: z.array(z.string()).optional(),
+  summary_markdown: z.string(),
+  timestamp: z.string().optional(),
+  title: z.string(),
+});
+
+export type AttackDiscovery = z.infer<typeof AttackDiscoverySchema>;

--- a/x-pack/solutions/security/plugins/discoveries/docs/action_execution_comparison.md
+++ b/x-pack/solutions/security/plugins/discoveries/docs/action_execution_comparison.md
@@ -1,0 +1,192 @@
+# Attack Discovery Action Execution: Hybrid Architecture (Option C)
+
+**Branch:** `attack_discovery_workflows_integration`
+**Date:** 2026-03-27
+**Feature flag:** `securitySolution.attackDiscoveryWorkflowsEnabled`
+
+---
+
+## Executive Summary
+
+Attack Discovery scheduling uses a **unified hybrid architecture** (Option C) regardless of the feature flag state:
+
+- **Alerting Framework** always owns scheduling, alert persistence, and action execution — with full throttling and frequency support.
+- **Workflows engine** owns only the generation pipeline (alert retrieval → generation → validation).
+
+The feature flag controls which *generation API* and *schedule CRUD API* the UI calls, but it does not change *how schedules are stored* or *how actions are executed*. Both FF ON and FF OFF use alerting-backed schedules. Action frequency settings (`onActiveAlert`, `onThrottleInterval`, `onActionGroupChange`) are always enforced by the Alerting Framework's `ActionScheduler`.
+
+---
+
+## 1. Feature Flag Mechanics
+
+### Server Side
+
+The feature flag is **not read directly** on the server for schedule storage. Both the public API (`elastic_assistant`) and the internal API (`discoveries`) create alerting rules via `AttackDiscoveryScheduleDataClient`. The `workflowConfig` field on the alerting rule's params tells the executor whether to delegate generation to the workflows engine.
+
+**File:** `x-pack/solutions/security/plugins/discoveries/server/lib/schedules/create_schedule_data_client/index.ts`
+
+### UI Side
+
+The UI reads the feature flag asynchronously and swaps which CRUD API it calls:
+
+```
+// use_schedule_api.ts
+const enabled = await featureFlags.getBooleanValue(
+  'securitySolution.attackDiscoveryWorkflowsEnabled',
+  false
+);
+setIsWorkflowsEnabled(enabled);
+```
+
+When `isWorkflowsEnabled` is `true`, CRUD hooks target the internal `discoveries` API. When `false`, they target the public `elastic_assistant` API.
+
+**File:** `x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/logic/use_schedule_api.ts`
+
+For generation, `useAttackDiscovery` checks the flag and calls either `callInternalGenerateApi()` or `callPublicGenerateApi()`:
+
+**File:** `x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.tsx`
+
+---
+
+## 2. Unified Architecture Summary
+
+| Dimension | FF OFF (Legacy) | FF ON (Internal) |
+|---|---|---|
+| **Generation API** | `POST /api/attack_discovery/_generate` (public, `elastic_assistant`) | `POST /internal/attack_discovery/_generate` (internal, `discoveries`) |
+| **Schedule API** | `POST /api/attack_discovery/schedules` (public) | `POST /internal/attack_discovery/schedules` (internal) |
+| **Schedule storage** | Alerting Rules | Alerting Rules (same) |
+| **Execution engine** | Alerting Framework task runner | Alerting Framework task runner (same) |
+| **Pipeline shape** | Monolithic: retrieve + generate + validate in one executor call | Three-phase: retrieval workflow → generation workflow → validation workflow |
+| **Action execution** | Implicit: `alertsClient.report()` → `ActionScheduler` queues actions async | Implicit: `alertsClient.report()` → `ActionScheduler` queues actions async (same) |
+| **Action frequency/throttling** | Fully enforced | Fully enforced (same) |
+| **Data client** | `AttackDiscoveryScheduleDataClient` | `AttackDiscoveryScheduleDataClient` (same) |
+| **Tag** | None | `attack-discovery-schedule` |
+| **Workflow config** | Not supported | `workflow_config` field enables delegation to workflows engine |
+
+---
+
+## 3. Action Execution Deep Dive
+
+### 3.1 Legacy Path (FF OFF)
+
+**File:** `x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.ts`
+
+The alerting rule executor:
+
+1. Retrieves anonymization fields
+2. Calls `generateAttackDiscoveries()` — a monolithic graph that handles alert retrieval, LLM invocation, and validation
+3. Filters hallucinated alerts
+4. Deduplicates discoveries against existing ones
+5. For each discovery, **reports an alert** to the framework:
+   ```
+   const { uuid: alertDocId } = alertsClient.report({
+     id: alertInstanceId,
+     actionGroup: 'default',
+   });
+   alertsClient.setAlertData({ id: alertInstanceId, payload: baseAlertDocument, context });
+   ```
+6. **The executor exits.** It never calls `actionsClient.execute()`.
+
+After the executor completes, the Alerting Framework's `ActionScheduler`:
+- Reads the rule's configured `actions` array
+- Applies frequency/throttling settings per action
+- Enqueues qualifying actions to the task queue via `actionsClient.bulkEnqueueExecution()`
+- Actions execute asynchronously in a separate task manager cycle
+
+### 3.2 Hybrid Path (FF ON)
+
+**File:** `x-pack/solutions/security/plugins/discoveries/server/lib/alert_executor/workflow_executor/index.ts`
+
+The alerting rule executor detects the `workflowConfig` field in rule params and delegates to `executeGenerationWorkflow()`:
+
+1. Calls `executeGenerationWorkflow()` — invokes the three-phase workflows pipeline (alert retrieval → generation → validation)
+2. For each discovery returned by the pipeline, **reports an alert** to the framework:
+   ```
+   alertsClient.report({ id: alertInstanceId, actionGroup: 'default' });
+   alertsClient.setAlertData({ id: alertInstanceId, payload: baseAlertDocument, context });
+   ```
+3. **The executor exits.** It never calls `actionsClient.execute()` directly.
+
+The Alerting Framework's `ActionScheduler` then handles action execution identically to the legacy path — with full frequency/throttling enforcement.
+
+**Key insight:** The executor's `workflowConfig` check is the only branch point. Actions are always handled by the framework regardless of which branch the executor takes.
+
+---
+
+## 4. Schedule CRUD Operations
+
+### 4.1 Data Client Factory
+
+**File:** `x-pack/solutions/security/plugins/discoveries/server/lib/schedules/create_schedule_data_client/index.ts`
+
+The `createScheduleDataClient()` factory always returns `AttackDiscoveryScheduleDataClient` (alerting-backed). There is no `AttackDiscoveryWorkflowScheduleDataClient` — the dual-client architecture has been removed.
+
+### 4.2 Route Pattern
+
+All CRUD routes follow a simple pattern:
+
+```typescript
+const dataClient = await createScheduleDataClient({ ... });
+await dataClient.someOperation({ id, ...params });
+```
+
+No branching, no fallback, no dual-client try/catch.
+
+---
+
+## 5. Cross-Mode Compatibility
+
+### 5.1 Schedule Created with FF OFF, then FF Turned ON
+
+**Behavior:** Works seamlessly.
+
+Schedules are alerting rules in both modes. The two APIs apply different tag strategies to maintain isolation:
+
+- **Public API:** no `applyTags` or `filterTags` — creates untagged schedules and reads all untagged alerting-backed schedules.
+- **Internal API:** `applyTags: ['attack-discovery-schedule']` on write + `filterTags: { includeTags: ['attack-discovery-schedule'] }` on read — creates and reads only internally-tagged schedules.
+
+When FF is turned ON, previously untagged schedules remain visible and manageable via the public API. The UI automatically switches to the internal API for new schedules.
+
+**Why isolation is maintained:** The public API's update path (`rulesClient.update()`) performs full parameter replacement. Its update transform omits `workflowConfig`, so updating an internally-created schedule via the public API would silently wipe ESQL queries and custom workflow IDs. Tag isolation prevents this data loss by ensuring each API only surfaces schedules it safely knows how to update.
+
+### 5.2 Schedule Created with FF ON, then FF Turned OFF
+
+**Behavior:** Works seamlessly for execution; internally-tagged schedules are not visible via the public API.
+
+Schedules created via the internal API are tagged with `attack-discovery-schedule`. When FF is OFF, the UI targets the public API. Because the internal API's `filterTags` restricts reads to the internal tag, and the public API has no `filterTags`, internally-tagged schedules do not appear in the public API's `_find` results.
+
+However, because all schedules are stored as alerting rules, they continue to execute normally. Re-enabling the flag restores full UI visibility via the internal API.
+
+### 5.3 No Orphaned Schedules
+
+Because both APIs use the same underlying storage (alerting rules), toggling the feature flag never orphans schedules. There is no separate workflow-definition storage that could become inaccessible.
+
+---
+
+## 6. Action Frequency/Throttling
+
+The Alerting Framework's `ActionScheduler` supports:
+
+| Setting | Behavior |
+|---|---|
+| `onActiveAlert` | Execute action every time the alert is active |
+| `onThrottleInterval` | Execute at most once per interval (e.g., "1h") |
+| `onActionGroupChange` | Execute only when alert transitions between action groups |
+| `summary: true` | Aggregate all alerts into a single action execution |
+
+These settings are configured per-action on the alerting rule and **always enforced** — in both the legacy path (FF OFF) and the hybrid path (FF ON). There is no path where frequency/throttling settings are ignored.
+
+---
+
+## 7. Key File Reference
+
+| File | Purpose |
+|---|---|
+| `x-pack/solutions/security/plugins/discoveries/server/lib/schedules/create_schedule_data_client/index.ts` | Data client factory — always returns alerting-backed client |
+| `x-pack/solutions/security/plugins/discoveries/server/lib/alert_executor/workflow_executor/index.ts` | Hybrid executor — delegates generation to workflows, reports via `alertsClient` |
+| `x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.ts` | Legacy executor — monolithic generation, reports via `alertsClient` |
+| `x-pack/solutions/security/plugins/discoveries/server/routes/post/schedules/create_schedule.ts` | Create route (internal API) |
+| `x-pack/solutions/security/plugins/discoveries/server/routes/get/schedules/find_schedules.ts` | Find route (internal API, tag-scoped) |
+| `x-pack/solutions/security/plugins/discoveries/server/routes/put/schedules/update_schedule.ts` | Update route (internal API) |
+| `x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/logic/use_schedule_api.ts` | UI hook swapper based on FF |
+| `x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.tsx` | Generation hook — FF branch for API selection |

--- a/x-pack/solutions/security/plugins/discoveries/event_logging_implementation.md
+++ b/x-pack/solutions/security/plugins/discoveries/event_logging_implementation.md
@@ -1,0 +1,269 @@
+# Event Logging Implementation for Workflow Steps
+
+## Overview
+
+This document describes the implementation of event logging for Attack Discovery workflow steps, enabling workflow-generated discoveries to be tracked and displayed in the Attack Discovery UI alongside discoveries generated via the public API.
+
+## Implementation Date
+
+January 13, 2026
+
+## Related Issue
+
+- **Beads Issue**: kibana-fg2.17
+- **Title**: Workflow steps must emit event log events for generation tracking
+
+## Problem Statement
+
+When users invoke the public Attack Discovery API (`POST /api/attack_discovery/_generate`), it logs events to the Elasticsearch event log. These events are tied together by `kibana.alert.rule.execution.uuid` and queried by the `GET /api/attack_discovery/generations` endpoint to display generation status in the UI.
+
+However, workflow-based generation steps did not emit these events, meaning:
+- Workflow-generated discoveries didn't appear in the generations list UI
+- No status tracking for workflow executions
+- No timing/performance metrics
+- Users couldn't see workflow execution history
+
+## Solution
+
+Implemented event logging in the `attack-discovery.generate` workflow step to emit the same event structure as the public API, and moved shared event logging utilities to `@kbn/discoveries` package to eliminate code duplication.
+
+## Architecture Changes
+
+### Before
+
+```
+elastic_assistant plugin
+├── Event logging utilities (duplicated)
+└── Public API with event logging
+
+discoveries plugin
+└── Workflow steps (no event logging)
+```
+
+### After
+
+```
+@kbn/discoveries package
+└── Event logging utilities (shared)
+    ├── constants.ts
+    ├── get_duration_nanoseconds.ts
+    └── write_attack_discovery_event.ts
+
+elastic_assistant plugin
+├── Public API (uses shared utilities)
+└── Imports from @kbn/discoveries
+
+discoveries plugin
+├── Workflow steps (uses shared utilities)
+└── Imports from @kbn/discoveries
+```
+
+## Implementation Details
+
+### Phase 1: Shared Utilities Migration
+
+**Files Created:**
+- `x-pack/solutions/security/packages/kbn-discoveries/src/persistence/event_logging/constants.ts`
+- `x-pack/solutions/security/packages/kbn-discoveries/src/persistence/event_logging/get_duration_nanoseconds.ts`
+- `x-pack/solutions/security/packages/kbn-discoveries/src/persistence/event_logging/write_attack_discovery_event.ts`
+- `x-pack/solutions/security/packages/kbn-discoveries/src/persistence/event_logging/get_duration_nanoseconds.test.ts`
+- `x-pack/solutions/security/packages/kbn-discoveries/src/persistence/event_logging/write_attack_discovery_event.test.ts`
+- `x-pack/solutions/security/packages/kbn-discoveries/src/persistence/event_logging/index.ts`
+- `x-pack/solutions/security/packages/kbn-discoveries/src/persistence/index.ts`
+
+**Key Design Decision:**
+- Abstracted `AttackDiscoveryDataClient` dependency to `EventLogRefresher` interface to avoid circular dependencies
+- This allows both plugins to use the utilities without tight coupling
+
+### Phase 2: elastic_assistant Updates
+
+**Files Modified:**
+- `x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/post/post_attack_discovery_generate.ts`
+- `x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/post/post_attack_discovery_generations_dismiss.ts`
+- `x-pack/solutions/security/plugins/elastic_assistant/common/constants.ts` (added deprecation comments)
+
+**Files Deleted:**
+- `x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/post/get_duration_nanoseconds/index.ts`
+- `x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/post/helpers/write_attack_discovery_event/index.ts`
+
+### Phase 3: discoveries Event Logging
+
+**Files Modified:**
+- `x-pack/solutions/security/plugins/discoveries/kibana.jsonc` (added eventLog dependency)
+- `x-pack/solutions/security/plugins/discoveries/server/types.ts` (added EventLogServiceSetup)
+- `x-pack/solutions/security/plugins/discoveries/server/plugin.ts` (create eventLogger)
+- `x-pack/solutions/security/plugins/discoveries/server/workflows/register_workflow_steps.ts` (pass eventLogger)
+- `x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step.ts` (implement event logging)
+
+**Event Logging Flow in generate_step.ts:**
+
+1. **At Start:**
+   - Get `executionUuid` from `context.contextManager.getContext().execution.id`
+   - Get authenticated user from security plugin
+   - Get spaceId from spaces plugin
+   - Get eventLogger and eventLogIndex
+   - Write `generation-started` event
+
+2. **On Success:**
+   - Calculate duration using `getDurationNanoseconds`
+   - Write `generation-succeeded` event with metrics:
+     - `alertsContextCount`: Number of alerts sent to LLM
+     - `newAlerts`: Number of discoveries generated
+     - `duration`: Time taken in nanoseconds
+
+3. **On Failure:**
+   - Calculate duration
+   - Write `generation-failed` event with:
+     - `reason`: Error message
+     - `outcome`: 'failure'
+
+## Event Structure
+
+Events follow the Elasticsearch event log schema:
+
+```typescript
+{
+  '@timestamp': string,
+  event: {
+    action: 'generation-started' | 'generation-succeeded' | 'generation-failed',
+    dataset: string,  // Connector ID
+    duration?: number,  // Duration in nanoseconds
+    end?: string,  // ISO timestamp
+    outcome?: 'success' | 'failure',
+    provider: 'securitySolution.attackDiscovery',
+    reason?: string,  // For failed generations
+    start?: string  // ISO timestamp
+  },
+  kibana: {
+    alert: {
+      rule: {
+        consumer: 'siem',
+        execution: {
+          metrics?: {
+            alert_counts: {
+              active?: number,  // Alerts sent to LLM
+              new?: number  // Discoveries generated
+            }
+          },
+          status?: string,  // Loading message
+          uuid: string  // Execution UUID (ties events together)
+        }
+      }
+    },
+    space_ids: [string]
+  },
+  message: string,
+  tags: ['securitySolution', 'attackDiscovery'],
+  user: {
+    name: string
+  }
+}
+```
+
+## Testing
+
+### Unit Tests
+
+Created comprehensive unit tests for shared utilities:
+
+**get_duration_nanoseconds.test.ts:**
+- ✅ Correct duration for 1.5 seconds
+- ✅ Correct duration for 0 seconds
+- ✅ Correct duration for 1 millisecond
+- ✅ Correct duration for 1 minute
+
+**write_attack_discovery_event.test.ts:**
+- ✅ Logs event with all required fields
+- ✅ Includes correct event structure
+- ✅ Includes metrics when alertsContextCount is provided
+- ✅ Includes metrics when newAlerts is provided
+- ✅ Includes both active and new counts in metrics
+- ✅ Trims reason field if longer than 1024 characters
+- ✅ Does not trim reason field if 1024 characters or less
+- ✅ Calls dataClient refreshEventLogIndex
+- ✅ Handles null dataClient gracefully
+- ✅ Includes duration when provided
+- ✅ Includes start and end timestamps when provided
+- ✅ Includes outcome when provided
+- ✅ Includes loading message as status when provided
+
+### Manual Verification Required
+
+The following verification steps require manual execution:
+
+1. **Start Kibana and Elasticsearch**
+   ```bash
+   yarn es snapshot --E xpack.security.enabled=true
+   yarn start --no-base-path
+   ```
+
+2. **Delete existing event log entries (clean slate)**
+   ```bash
+   curl -u elastic:changeme -X POST "http://localhost:9200/.kibana-event-log-*/_delete_by_query" -H 'Content-Type: application/json' -d'
+   {
+     "query": {
+       "term": {
+         "event.provider": "securitySolution.attackDiscovery"
+       }
+     }
+   }
+   '
+   ```
+
+3. **Execute workflow manually**
+   - Navigate to Workflows UI
+   - Open an Attack discovery workflow (e.g., Attack discovery - Generation)
+   - Click "Run"
+   - Wait for completion
+
+4. **Query event log**
+   ```bash
+   curl -u elastic:changeme "http://localhost:9200/.kibana-event-log-*/_search?pretty" -H 'Content-Type: application/json' -d'
+   {
+     "query": {
+       "term": {
+         "event.provider": "securitySolution.attackDiscovery"
+       }
+     },
+     "sort": [{"@timestamp": "asc"}]
+   }
+   '
+   ```
+
+5. **Test GET /generations endpoint**
+   ```bash
+   curl -u elastic:changeme "http://localhost:5601/api/attack_discovery/generations?page=1&perPage=10" -H 'kbn-xsrf: true'
+   ```
+
+6. **Test UI**
+   - Navigate to Attack Discovery UI
+   - Verify workflow-generated discoveries appear
+
+## Benefits
+
+1. **Unified Tracking**: Workflow and API generations tracked consistently
+2. **Code Reuse**: Eliminated ~200 lines of duplicated code
+3. **UI Integration**: Workflow executions visible in Attack Discovery UI
+4. **Metrics**: Performance and success metrics for workflow executions
+5. **Debugging**: Event log provides audit trail for troubleshooting
+
+## Breaking Changes
+
+None. This is an additive change that doesn't affect existing functionality.
+
+## Deprecations
+
+Added deprecation comments to event logging constants in `elastic_assistant/common/constants.ts` pointing to `@kbn/discoveries`. These can be removed in a future cleanup PR.
+
+## Future Enhancements
+
+1. **Validation Events**: Consider adding separate event logging for the validation step
+2. **Additional Metrics**: Track more detailed LLM invocation metrics
+3. **Event Retention**: Configure event log retention policies
+4. **Alerting**: Set up alerts for failed generations
+
+## References
+
+- **Kibana API Docs**: https://www.elastic.co/docs/api/doc/kibana/operation/operation-getattackdiscoverygenerations
+- **Event Log Plugin**: `x-pack/platform/plugins/event_log`
+- **Public API Implementation**: `x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/post/post_attack_discovery_generate.ts`

--- a/x-pack/solutions/security/plugins/discoveries/jest.config.js
+++ b/x-pack/solutions/security/plugins/discoveries/jest.config.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/x-pack/solutions/security/plugins/discoveries'],
+  preset: '@kbn/test',
+  coverageDirectory:
+    '<rootDir>/target/kibana-coverage/jest/x-pack/solutions/security/plugins/discoveries',
+  coverageReporters: ['text', 'html'],
+  collectCoverageFrom: [
+    '<rootDir>/x-pack/solutions/security/plugins/discoveries/server/routes/post/validate/**/*.{ts,tsx}',
+    '<rootDir>/x-pack/solutions/security/plugins/discoveries/server/skills/**/*.{ts,tsx}',
+    '<rootDir>/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step.ts',
+    '<rootDir>/x-pack/solutions/security/plugins/discoveries/server/lib/attack_discovery_*.ts',
+  ],
+};

--- a/x-pack/solutions/security/plugins/discoveries/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/discoveries/kibana.jsonc
@@ -1,0 +1,39 @@
+{
+  "type": "plugin",
+  "id": "@kbn/discoveries-plugin",
+  "owner": [
+    "@elastic/security-generative-ai"
+  ],
+  "group": "security",
+  "visibility": "private",
+  "description": "Discoveries plugin for Attack Discovery workflows integration",
+  "plugin": {
+    "id": "discoveries",
+    "browser": true,
+    "server": true,
+    "configPath": [
+      "xpack",
+      "discoveries"
+    ],
+    "requiredPlugins": [
+      "actions",
+      "alerting",
+      "eventLog",
+      "security",
+      "workflowsExtensions"
+    ],
+    "optionalPlugins": [
+      "agentBuilder",
+      "elasticAssistant",
+      "inference",
+      "ruleRegistry",
+      "spaces",
+      "workflowsManagement"
+    ],
+    "requiredBundles": []
+  }
+}
+
+
+
+

--- a/x-pack/solutions/security/plugins/discoveries/package.json
+++ b/x-pack/solutions/security/plugins/discoveries/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@kbn/discoveries-plugin",
+  "version": "1.0.0",
+  "private": true,
+  "license": "Elastic License 2.0",
+  "dependencies": {
+    "@kbn/security-ai-prompts": "link:../../packages/security-ai-prompts"
+  }
+}
+
+
+
+

--- a/x-pack/solutions/security/plugins/discoveries/public/eui_icons.d.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/eui_icons.d.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+declare module '@elastic/eui/es/components/icon/assets/*' {
+  import type * as React from 'react';
+
+  interface SVGRProps {
+    title?: string;
+    titleId?: string;
+  }
+
+  export const icon: ({
+    title,
+    titleId,
+    ...props
+  }: React.SVGProps<SVGSVGElement> & SVGRProps) => React.JSX.Element;
+  export {};
+}

--- a/x-pack/solutions/security/plugins/discoveries/public/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PluginInitializerContext } from '@kbn/core/public';
+import { DiscoveriesPublicPlugin } from './plugin';
+
+export type { DiscoveriesPublicPluginSetup, DiscoveriesPublicPluginStart } from './types';
+
+export const plugin = (initializerContext: PluginInitializerContext) =>
+  new DiscoveriesPublicPlugin(initializerContext);

--- a/x-pack/solutions/security/plugins/discoveries/public/plugin.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/plugin.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { coreMock } from '@kbn/core/public/mocks';
+
+import { DIAGNOSTIC_REPORT_ATTACHMENT_TYPE } from '../common/constants';
+import { DiscoveriesPublicPlugin } from './plugin';
+import type { DiscoveriesPublicPluginSetupDeps, DiscoveriesPublicPluginStartDeps } from './types';
+
+const createSetupDeps = (): DiscoveriesPublicPluginSetupDeps => ({
+  workflowsExtensions: {
+    registerStepDefinition: jest.fn(),
+  } as unknown as DiscoveriesPublicPluginSetupDeps['workflowsExtensions'],
+});
+
+const createStartDeps = ({
+  withAgentBuilder = false,
+}: { withAgentBuilder?: boolean } = {}): DiscoveriesPublicPluginStartDeps => ({
+  ...(withAgentBuilder
+    ? {
+        agentBuilder: {
+          attachments: {
+            addAttachmentType: jest.fn(),
+          },
+        } as unknown as NonNullable<DiscoveriesPublicPluginStartDeps['agentBuilder']>,
+      }
+    : {}),
+});
+
+describe('DiscoveriesPublicPlugin', () => {
+  describe('setup', () => {
+    it('registers step definitions with workflowsExtensions', () => {
+      const context = coreMock.createPluginInitializerContext();
+      const plugin = new DiscoveriesPublicPlugin(context);
+      const coreSetup = coreMock.createSetup();
+      const setupDeps = createSetupDeps();
+
+      plugin.setup(coreSetup, setupDeps);
+
+      expect(setupDeps.workflowsExtensions.registerStepDefinition).toHaveBeenCalled();
+    });
+  });
+
+  describe('start', () => {
+    it('registers the diagnostic report attachment type when agentBuilder is available', () => {
+      const context = coreMock.createPluginInitializerContext();
+      const plugin = new DiscoveriesPublicPlugin(context);
+      const coreSetup = coreMock.createSetup();
+      const setupDeps = createSetupDeps();
+      const coreStart = coreMock.createStart();
+      const startDeps = createStartDeps({ withAgentBuilder: true });
+
+      plugin.setup(coreSetup, setupDeps);
+      plugin.start(coreStart, startDeps);
+
+      expect(startDeps.agentBuilder?.attachments.addAttachmentType).toHaveBeenCalledWith(
+        DIAGNOSTIC_REPORT_ATTACHMENT_TYPE,
+        expect.objectContaining({
+          getIcon: expect.any(Function),
+          getLabel: expect.any(Function),
+        })
+      );
+    });
+
+    it('returns "document" from getIcon', () => {
+      const context = coreMock.createPluginInitializerContext();
+      const plugin = new DiscoveriesPublicPlugin(context);
+      const coreSetup = coreMock.createSetup();
+      const setupDeps = createSetupDeps();
+      const coreStart = coreMock.createStart();
+      const startDeps = createStartDeps({ withAgentBuilder: true });
+
+      plugin.setup(coreSetup, setupDeps);
+      plugin.start(coreStart, startDeps);
+
+      const { getIcon } = (startDeps.agentBuilder?.attachments.addAttachmentType as jest.Mock).mock
+        .calls[0][1] as Record<string, () => string>;
+
+      expect(getIcon()).toBe('document');
+    });
+
+    it('returns "Diagnostic report" from getLabel', () => {
+      const context = coreMock.createPluginInitializerContext();
+      const plugin = new DiscoveriesPublicPlugin(context);
+      const coreSetup = coreMock.createSetup();
+      const setupDeps = createSetupDeps();
+      const coreStart = coreMock.createStart();
+      const startDeps = createStartDeps({ withAgentBuilder: true });
+
+      plugin.setup(coreSetup, setupDeps);
+      plugin.start(coreStart, startDeps);
+
+      const { getLabel } = (startDeps.agentBuilder?.attachments.addAttachmentType as jest.Mock).mock
+        .calls[0][1] as Record<string, () => string>;
+
+      expect(getLabel()).toBe('Diagnostic report');
+    });
+
+    it('does not throw when agentBuilder is not available', () => {
+      const context = coreMock.createPluginInitializerContext();
+      const plugin = new DiscoveriesPublicPlugin(context);
+      const coreSetup = coreMock.createSetup();
+      const setupDeps = createSetupDeps();
+      const coreStart = coreMock.createStart();
+      const startDeps = createStartDeps({ withAgentBuilder: false });
+
+      plugin.setup(coreSetup, setupDeps);
+
+      expect(() => plugin.start(coreStart, startDeps)).not.toThrow();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/public/plugin.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/plugin.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
+import { i18n } from '@kbn/i18n';
+
+import { DIAGNOSTIC_REPORT_ATTACHMENT_TYPE } from '../common/constants';
+import type {
+  DiscoveriesPublicPluginSetup,
+  DiscoveriesPublicPluginSetupDeps,
+  DiscoveriesPublicPluginStart,
+  DiscoveriesPublicPluginStartDeps,
+} from './types';
+import {
+  defaultAlertRetrievalStepPublicDefinition,
+  defaultValidationStepPublicDefinition,
+  generateStepPublicDefinition,
+  persistDiscoveriesStepPublicDefinition,
+  runStepPublicDefinition,
+} from './step_types';
+
+export class DiscoveriesPublicPlugin
+  implements
+    Plugin<
+      DiscoveriesPublicPluginSetup,
+      DiscoveriesPublicPluginStart,
+      DiscoveriesPublicPluginSetupDeps,
+      DiscoveriesPublicPluginStartDeps
+    >
+{
+  constructor(_context: PluginInitializerContext) {}
+
+  public setup(
+    _core: CoreSetup<DiscoveriesPublicPluginStartDeps, DiscoveriesPublicPluginStart>,
+    plugins: DiscoveriesPublicPluginSetupDeps
+  ): DiscoveriesPublicPluginSetup {
+    plugins.workflowsExtensions.registerStepDefinition(defaultAlertRetrievalStepPublicDefinition);
+    plugins.workflowsExtensions.registerStepDefinition(defaultValidationStepPublicDefinition);
+    plugins.workflowsExtensions.registerStepDefinition(generateStepPublicDefinition);
+    plugins.workflowsExtensions.registerStepDefinition(persistDiscoveriesStepPublicDefinition);
+    plugins.workflowsExtensions.registerStepDefinition(runStepPublicDefinition);
+
+    return {};
+  }
+
+  public start(
+    _core: CoreStart,
+    plugins: DiscoveriesPublicPluginStartDeps
+  ): DiscoveriesPublicPluginStart {
+    plugins.agentBuilder?.attachments.addAttachmentType(DIAGNOSTIC_REPORT_ATTACHMENT_TYPE, {
+      getIcon: () => 'document',
+      getLabel: () =>
+        i18n.translate('xpack.discoveries.attachments.diagnosticReport.label', {
+          defaultMessage: 'Diagnostic report',
+        }),
+    });
+
+    return {};
+  }
+
+  public stop() {}
+}

--- a/x-pack/solutions/security/plugins/discoveries/public/step_types/default_alert_retrieval_step.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/step_types/default_alert_retrieval_step.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { StepCategory } from '@kbn/workflows';
+import { defaultAlertRetrievalStepPublicDefinition } from './default_alert_retrieval_step';
+import { DefaultAlertRetrievalStepTypeId } from '../../common/step_types/default_alert_retrieval_step';
+
+describe('defaultAlertRetrievalStepPublicDefinition', () => {
+  describe('id', () => {
+    it('returns the correct id', () => {
+      expect(defaultAlertRetrievalStepPublicDefinition.id).toBe(DefaultAlertRetrievalStepTypeId);
+    });
+
+    it('returns attack-discovery.defaultAlertRetrieval', () => {
+      expect(defaultAlertRetrievalStepPublicDefinition.id).toBe(
+        'attack-discovery.defaultAlertRetrieval'
+      );
+    });
+  });
+
+  describe('label', () => {
+    it('is defined', () => {
+      expect(defaultAlertRetrievalStepPublicDefinition.label).toBeDefined();
+    });
+
+    it('is a string', () => {
+      expect(typeof defaultAlertRetrievalStepPublicDefinition.label).toBe('string');
+    });
+
+    it('is not empty', () => {
+      expect(defaultAlertRetrievalStepPublicDefinition.label.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('description', () => {
+    it('is defined', () => {
+      expect(defaultAlertRetrievalStepPublicDefinition.description).toBeDefined();
+    });
+
+    it('is a string', () => {
+      expect(typeof defaultAlertRetrievalStepPublicDefinition.description).toBe('string');
+    });
+
+    it('is not empty', () => {
+      expect(defaultAlertRetrievalStepPublicDefinition.description?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('icon', () => {
+    it('is defined', () => {
+      expect(defaultAlertRetrievalStepPublicDefinition.icon).toBeDefined();
+    });
+  });
+
+  describe('category', () => {
+    it('is set to Elasticsearch', () => {
+      expect(defaultAlertRetrievalStepPublicDefinition.category).toBe(StepCategory.Elasticsearch);
+    });
+  });
+
+  describe('schemas', () => {
+    it('has inputSchema defined', () => {
+      expect(defaultAlertRetrievalStepPublicDefinition.inputSchema).toBeDefined();
+    });
+
+    it('has outputSchema defined', () => {
+      expect(defaultAlertRetrievalStepPublicDefinition.outputSchema).toBeDefined();
+    });
+  });
+
+  describe('documentation', () => {
+    it('is defined', () => {
+      expect(defaultAlertRetrievalStepPublicDefinition.documentation).toBeDefined();
+    });
+
+    it('has details defined', () => {
+      expect(defaultAlertRetrievalStepPublicDefinition.documentation?.details).toBeDefined();
+    });
+
+    it('has details as a string', () => {
+      expect(typeof defaultAlertRetrievalStepPublicDefinition.documentation?.details).toBe(
+        'string'
+      );
+    });
+
+    it('has non-empty details', () => {
+      expect(
+        defaultAlertRetrievalStepPublicDefinition.documentation?.details?.length
+      ).toBeGreaterThan(0);
+    });
+
+    it('has examples defined', () => {
+      expect(defaultAlertRetrievalStepPublicDefinition.documentation?.examples).toBeDefined();
+    });
+
+    it('has examples as an array', () => {
+      expect(Array.isArray(defaultAlertRetrievalStepPublicDefinition.documentation?.examples)).toBe(
+        true
+      );
+    });
+
+    it('has at least one example', () => {
+      expect(
+        defaultAlertRetrievalStepPublicDefinition.documentation?.examples?.length
+      ).toBeGreaterThan(0);
+    });
+
+    it('has at least 3 examples', () => {
+      expect(
+        defaultAlertRetrievalStepPublicDefinition.documentation?.examples?.length
+      ).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('documentation examples', () => {
+    const examples = defaultAlertRetrievalStepPublicDefinition.documentation?.examples ?? [];
+
+    it.each(examples.map((example, index) => [index, example]))(
+      'example %i contains YAML code block',
+      (_index, example) => {
+        expect(example).toContain('```yaml');
+      }
+    );
+
+    it.each(examples.map((example, index) => [index, example]))(
+      'example %i closes YAML code block',
+      (_index, example) => {
+        expect(example).toContain('```');
+      }
+    );
+
+    it.each(examples.map((example, index) => [index, example]))(
+      'example %i references the correct step type',
+      (_index, example) => {
+        expect(example).toContain('attack-discovery.defaultAlertRetrieval');
+      }
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/public/step_types/default_alert_retrieval_step.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/step_types/default_alert_retrieval_step.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import type { PublicStepDefinition } from '@kbn/workflows-extensions/public';
+import {
+  DefaultAlertRetrievalStepCommonDefinition,
+  DefaultAlertRetrievalStepTypeId,
+} from '../../common/step_types/default_alert_retrieval_step';
+
+export const defaultAlertRetrievalStepPublicDefinition: PublicStepDefinition = {
+  ...DefaultAlertRetrievalStepCommonDefinition,
+
+  icon: React.lazy(() =>
+    import('@elastic/eui/es/components/icon/assets/search').then(({ icon }) => ({
+      default: icon,
+    }))
+  ),
+
+  documentation: {
+    details: i18n.translate(
+      'xpack.discoveries.workflowSteps.defaultAlertRetrieval.documentation.details',
+      {
+        defaultMessage: `This step retrieves security alerts from Elasticsearch and prepares them for Attack Discovery generation.
+
+**Key Features:**
+- Queries alerts from specified index pattern
+- Anonymizes sensitive fields based on configuration
+- Converts alerts to LangChain Document format
+- Returns both original and anonymized alerts
+- Provides replacement map for de-anonymization
+
+**Configuration:**
+- {alertsIndexPattern}: Alert index pattern to query (e.g., '.alerts-security.alerts-default')
+- {anonymizationFields}: Array of field configurations specifying which fields to allow/anonymize
+- {apiConfig}: Connector configuration for LLM
+- {size}: Maximum number of alerts to retrieve (default: 100)
+- {start}/{end}: Time range for alert query (e.g., 'now-24h', 'now')
+- {filter}: Optional KQL query to filter alerts
+
+**Anonymization:**
+Fields can be configured as:
+- {allowed}: Include in output (allowed: true)
+- {anonymized}: Replace with generic placeholder (anonymized: true)
+- {excluded}: Omit from output (allowed: false)`,
+        values: {
+          alertsIndexPattern: '`alerts_index_pattern`',
+          anonymizationFields: '`anonymization_fields`',
+          apiConfig: '`api_config`',
+          size: '`size`',
+          start: '`start`',
+          end: '`end`',
+          filter: '`filter`',
+          allowed: 'allowed',
+          anonymized: 'anonymized',
+          excluded: 'excluded',
+        },
+      }
+    ),
+    examples: [
+      `## Basic alert retrieval (last 24 hours)
+\`\`\`yaml
+- name: retrieve_alerts
+  type: ${DefaultAlertRetrievalStepTypeId}
+  timeout: '5m'
+  with:
+    alerts_index_pattern: '.alerts-security.alerts-default'
+    size: 100
+    start: 'now-24h'
+    end: 'now'
+    api_config:
+      action_type_id: '.gen-ai'
+      connector_id: my-connector
+\`\`\``,
+
+      `## Custom time range
+\`\`\`yaml
+- name: retrieve_alerts
+  type: ${DefaultAlertRetrievalStepTypeId}
+  with:
+    alerts_index_pattern: '.alerts-security.alerts-default'
+    size: 150
+    start: '2024-01-01T00:00:00Z'
+    end: '2024-01-31T23:59:59Z'
+    api_config:
+      action_type_id: '.gemini'
+      connector_id: my-gemini-connector
+\`\`\``,
+
+      `## With KQL filter
+\`\`\`yaml
+- name: retrieve_alerts
+  type: ${DefaultAlertRetrievalStepTypeId}
+  with:
+    alerts_index_pattern: '.alerts-security.alerts-default'
+    size: 100
+    start: 'now-7d'
+    end: 'now'
+    filter:
+      query: 'kibana.alert.severity: "high" OR kibana.alert.severity: "critical"'
+      language: 'kuery'
+    api_config:
+      action_type_id: '.gen-ai'
+      connector_id: my-connector
+\`\`\``,
+
+      `## Custom anonymization (minimal fields)
+\`\`\`yaml
+- name: retrieve_alerts
+  type: ${DefaultAlertRetrievalStepTypeId}
+  with:
+    alerts_index_pattern: '.alerts-security.alerts-default'
+    size: 100
+    start: 'now-24h'
+    end: 'now'
+    anonymization_fields:
+      - id: 'field-@timestamp'
+        field: '@timestamp'
+        allowed: true
+        anonymized: false
+      - id: 'field-event-action'
+        field: 'event.action'
+        allowed: true
+        anonymized: false
+      - id: 'field-host-name'
+        field: 'host.name'
+        allowed: true
+        anonymized: true  # Replace with generic placeholder
+      - id: 'field-user-name'
+        field: 'user.name'
+        allowed: true
+        anonymized: true
+    api_config:
+      action_type_id: '.gen-ai'
+      connector_id: my-connector
+\`\`\``,
+
+      `## Pass outputs to generation step
+\`\`\`yaml
+- name: retrieve_alerts
+  type: ${DefaultAlertRetrievalStepTypeId}
+  with:
+    alerts_index_pattern: '.alerts-security.alerts-default'
+    size: 100
+    start: 'now-24h'
+    end: 'now'
+    api_config:
+      action_type_id: '.gen-ai'
+      connector_id: my-connector
+
+- name: generate_discoveries
+  type: attack-discovery.generate
+  timeout: '10m'
+  with:
+    type: attack_discovery
+    alerts: \${{ steps.retrieve_alerts.output.alerts }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    replacements: \${{ steps.retrieve_alerts.output.replacements }}
+\`\`\``,
+    ],
+  },
+};

--- a/x-pack/solutions/security/plugins/discoveries/public/step_types/default_validation_step.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/step_types/default_validation_step.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { StepCategory } from '@kbn/workflows';
+import { defaultValidationStepPublicDefinition } from './default_validation_step';
+import { DefaultValidationStepTypeId } from '../../common/step_types/default_validation_step';
+
+describe('defaultValidationStepPublicDefinition', () => {
+  describe('id', () => {
+    it('returns the correct id', () => {
+      expect(defaultValidationStepPublicDefinition.id).toBe(DefaultValidationStepTypeId);
+    });
+
+    it('returns attack-discovery.defaultValidation', () => {
+      expect(defaultValidationStepPublicDefinition.id).toBe('attack-discovery.defaultValidation');
+    });
+  });
+
+  describe('label', () => {
+    it('is defined', () => {
+      expect(defaultValidationStepPublicDefinition.label).toBeDefined();
+    });
+
+    it('is a string', () => {
+      expect(typeof defaultValidationStepPublicDefinition.label).toBe('string');
+    });
+
+    it('is not empty', () => {
+      expect(defaultValidationStepPublicDefinition.label.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('description', () => {
+    it('is defined', () => {
+      expect(defaultValidationStepPublicDefinition.description).toBeDefined();
+    });
+
+    it('is a string', () => {
+      expect(typeof defaultValidationStepPublicDefinition.description).toBe('string');
+    });
+
+    it('is not empty', () => {
+      expect(defaultValidationStepPublicDefinition.description?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('icon', () => {
+    it('is defined', () => {
+      expect(defaultValidationStepPublicDefinition.icon).toBeDefined();
+    });
+  });
+
+  describe('category', () => {
+    it('is set to Kibana', () => {
+      expect(defaultValidationStepPublicDefinition.category).toBe(StepCategory.Kibana);
+    });
+  });
+
+  describe('schemas', () => {
+    it('has inputSchema defined', () => {
+      expect(defaultValidationStepPublicDefinition.inputSchema).toBeDefined();
+    });
+
+    it('has outputSchema defined', () => {
+      expect(defaultValidationStepPublicDefinition.outputSchema).toBeDefined();
+    });
+  });
+
+  describe('documentation', () => {
+    it('is defined', () => {
+      expect(defaultValidationStepPublicDefinition.documentation).toBeDefined();
+    });
+
+    it('has details defined', () => {
+      expect(defaultValidationStepPublicDefinition.documentation?.details).toBeDefined();
+    });
+
+    it('has details as a string', () => {
+      expect(typeof defaultValidationStepPublicDefinition.documentation?.details).toBe('string');
+    });
+
+    it('has non-empty details', () => {
+      expect(defaultValidationStepPublicDefinition.documentation?.details?.length).toBeGreaterThan(
+        0
+      );
+    });
+
+    it('has examples defined', () => {
+      expect(defaultValidationStepPublicDefinition.documentation?.examples).toBeDefined();
+    });
+
+    it('has examples as an array', () => {
+      expect(Array.isArray(defaultValidationStepPublicDefinition.documentation?.examples)).toBe(
+        true
+      );
+    });
+
+    it('has at least one example', () => {
+      expect(defaultValidationStepPublicDefinition.documentation?.examples?.length).toBeGreaterThan(
+        0
+      );
+    });
+
+    it('has at least 3 examples', () => {
+      expect(
+        defaultValidationStepPublicDefinition.documentation?.examples?.length
+      ).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('documentation examples', () => {
+    const examples = defaultValidationStepPublicDefinition.documentation?.examples ?? [];
+
+    it.each(examples.map((example, index) => [index, example]))(
+      'example %i contains YAML code block',
+      (_index, example) => {
+        expect(example).toContain('```yaml');
+      }
+    );
+
+    it.each(examples.map((example, index) => [index, example]))(
+      'example %i closes YAML code block',
+      (_index, example) => {
+        expect(example).toContain('```');
+      }
+    );
+
+    it.each(examples.map((example, index) => [index, example]))(
+      'example %i references the correct step type',
+      (_index, example) => {
+        expect(example).toContain('attack-discovery.defaultValidation');
+      }
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/public/step_types/default_validation_step.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/step_types/default_validation_step.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import type { PublicStepDefinition } from '@kbn/workflows-extensions/public';
+import {
+  DefaultValidationStepCommonDefinition,
+  DefaultValidationStepTypeId,
+} from '../../common/step_types/default_validation_step';
+import { PersistDiscoveriesStepTypeId } from '../../common/step_types/persist_discoveries_step';
+
+export const defaultValidationStepPublicDefinition: PublicStepDefinition = {
+  ...DefaultValidationStepCommonDefinition,
+
+  icon: React.lazy(() =>
+    import('@elastic/eui/es/components/icon/assets/inspect').then(({ icon }) => ({
+      default: icon,
+    }))
+  ),
+
+  documentation: {
+    details: i18n.translate(
+      'xpack.discoveries.workflowSteps.defaultValidation.documentation.details',
+      {
+        defaultMessage: `This step validates generated Attack Discoveries by detecting hallucinated alert references and removing duplicate discoveries. It does not persist results; use the {persistStep} step afterward to write validated discoveries to Elasticsearch.
+
+**Key Features:**
+- Detects and filters hallucinated alert IDs that do not exist in the alerts index
+- Deduplicates discoveries to prevent redundant results
+- Enriches discovery metadata with validation status
+- De-anonymizes fields using replacement map (optional)
+- Renders markdown fields for display (optional)
+
+**Configuration:**
+- {attackDiscoveries}: Array of discoveries from generation step
+- {anonymizedAlerts}: Original anonymized alerts for context
+- {replacements}: Map for de-anonymizing sensitive fields
+- {apiConfig}: Connector configuration used for generation
+- {connectorName}: Display name of the connector
+- {generationUuid}: Execution UUID linking discoveries to generation event
+- {alertsContextCount}: Number of alerts analyzed
+- {enableFieldRendering}: Render markdown fields (default: true)
+- {withReplacements}: Apply de-anonymization (default: false)
+
+**Output:**
+Returns validated discoveries with hallucinated references removed and duplicates filtered out. Pipe these into the {persistStep} step to write them to the Attack Discovery alerts index.`,
+        values: {
+          alertsContextCount: '`alerts_context_count`',
+          anonymizedAlerts: '`anonymized_alerts`',
+          apiConfig: '`api_config`',
+          attackDiscoveries: '`attack_discoveries`',
+          connectorName: '`connector_name`',
+          enableFieldRendering: '`enable_field_rendering`',
+          generationUuid: '`generation_uuid`',
+          persistStep: '`attack-discovery.persistDiscoveries`',
+          replacements: '`replacements`',
+          withReplacements: '`with_replacements`',
+        },
+      }
+    ),
+    examples: [
+      `## Basic validation
+\`\`\`yaml
+- name: validate_discoveries
+  type: ${DefaultValidationStepTypeId}
+  with:
+    attack_discoveries: \${{ steps.generate_discoveries.output.attack_discoveries }}
+    anonymized_alerts: \${{ steps.retrieve_alerts.output.anonymized_alerts }}
+    replacements: \${{ steps.generate_discoveries.output.replacements }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    connector_name: \${{ steps.retrieve_alerts.output.connector_name }}
+    generation_uuid: \${{ steps.generate_discoveries.output.execution_uuid }}
+    alerts_context_count: \${{ steps.retrieve_alerts.output.alerts_context_count }}
+\`\`\``,
+
+      `## Validate then persist
+\`\`\`yaml
+- name: validate_discoveries
+  type: ${DefaultValidationStepTypeId}
+  with:
+    attack_discoveries: \${{ steps.generate_discoveries.output.attack_discoveries }}
+    anonymized_alerts: \${{ steps.retrieve_alerts.output.anonymized_alerts }}
+    replacements: \${{ steps.generate_discoveries.output.replacements }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    connector_name: \${{ steps.retrieve_alerts.output.connector_name }}
+    generation_uuid: \${{ steps.generate_discoveries.output.execution_uuid }}
+    alerts_context_count: \${{ steps.retrieve_alerts.output.alerts_context_count }}
+
+- name: persist_discoveries
+  type: ${PersistDiscoveriesStepTypeId}
+  with:
+    attack_discoveries: \${{ steps.validate_discoveries.output.validated_discoveries }}
+    anonymized_alerts: \${{ steps.retrieve_alerts.output.anonymized_alerts }}
+    replacements: \${{ steps.generate_discoveries.output.replacements }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    connector_name: \${{ steps.retrieve_alerts.output.connector_name }}
+    generation_uuid: \${{ steps.generate_discoveries.output.execution_uuid }}
+    alerts_context_count: \${{ steps.retrieve_alerts.output.alerts_context_count }}
+\`\`\``,
+
+      `## Validation with de-anonymization enabled
+\`\`\`yaml
+- name: validate_discoveries
+  type: ${DefaultValidationStepTypeId}
+  with:
+    attack_discoveries: \${{ steps.generate_discoveries.output.attack_discoveries }}
+    anonymized_alerts: \${{ steps.retrieve_alerts.output.anonymized_alerts }}
+    replacements: \${{ steps.generate_discoveries.output.replacements }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    connector_name: \${{ steps.retrieve_alerts.output.connector_name }}
+    generation_uuid: \${{ steps.generate_discoveries.output.execution_uuid }}
+    alerts_context_count: \${{ steps.retrieve_alerts.output.alerts_context_count }}
+    with_replacements: true
+\`\`\``,
+
+      `## Full end-to-end pipeline: retrieve, generate, validate, persist
+\`\`\`yaml
+- name: retrieve_alerts
+  type: attack-discovery.defaultAlertRetrieval
+  timeout: '5m'
+  with:
+    alerts_index_pattern: '.alerts-security.alerts-default'
+    size: 100
+    start: 'now-24h'
+    end: 'now'
+    api_config:
+      action_type_id: '.gen-ai'
+      connector_id: my-connector
+
+- name: generate_discoveries
+  type: attack-discovery.generate
+  timeout: '10m'
+  with:
+    type: attack_discovery
+    alerts: \${{ steps.retrieve_alerts.output.alerts }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    replacements: \${{ steps.retrieve_alerts.output.replacements }}
+
+- name: validate_discoveries
+  type: ${DefaultValidationStepTypeId}
+  with:
+    attack_discoveries: \${{ steps.generate_discoveries.output.attack_discoveries }}
+    anonymized_alerts: \${{ steps.retrieve_alerts.output.anonymized_alerts }}
+    replacements: \${{ steps.generate_discoveries.output.replacements }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    connector_name: \${{ steps.retrieve_alerts.output.connector_name }}
+    generation_uuid: \${{ steps.generate_discoveries.output.execution_uuid }}
+    alerts_context_count: \${{ steps.retrieve_alerts.output.alerts_context_count }}
+
+- name: persist_discoveries
+  type: ${PersistDiscoveriesStepTypeId}
+  with:
+    attack_discoveries: \${{ steps.validate_discoveries.output.validated_discoveries }}
+    anonymized_alerts: \${{ steps.retrieve_alerts.output.anonymized_alerts }}
+    replacements: \${{ steps.generate_discoveries.output.replacements }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    connector_name: \${{ steps.retrieve_alerts.output.connector_name }}
+    generation_uuid: \${{ steps.generate_discoveries.output.execution_uuid }}
+    alerts_context_count: \${{ steps.retrieve_alerts.output.alerts_context_count }}
+    enable_field_rendering: true
+    with_replacements: true
+\`\`\``,
+    ],
+  },
+};

--- a/x-pack/solutions/security/plugins/discoveries/public/step_types/generate_step.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/step_types/generate_step.test.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { StepCategory } from '@kbn/workflows';
+import { generateStepPublicDefinition } from './generate_step';
+import { GenerateStepTypeId } from '../../common/step_types/generate_step';
+
+describe('generateStepPublicDefinition', () => {
+  describe('id', () => {
+    it('returns the correct id', () => {
+      expect(generateStepPublicDefinition.id).toBe(GenerateStepTypeId);
+    });
+
+    it('returns attack-discovery.generate', () => {
+      expect(generateStepPublicDefinition.id).toBe('attack-discovery.generate');
+    });
+  });
+
+  describe('label', () => {
+    it('is defined', () => {
+      expect(generateStepPublicDefinition.label).toBeDefined();
+    });
+
+    it('is a string', () => {
+      expect(typeof generateStepPublicDefinition.label).toBe('string');
+    });
+
+    it('is not empty', () => {
+      expect(generateStepPublicDefinition.label.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('description', () => {
+    it('is defined', () => {
+      expect(generateStepPublicDefinition.description).toBeDefined();
+    });
+
+    it('is a string', () => {
+      expect(typeof generateStepPublicDefinition.description).toBe('string');
+    });
+
+    it('is not empty', () => {
+      expect(generateStepPublicDefinition.description?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('icon', () => {
+    it('is defined', () => {
+      expect(generateStepPublicDefinition.icon).toBeDefined();
+    });
+  });
+
+  describe('category', () => {
+    it('is set to AI', () => {
+      expect(generateStepPublicDefinition.category).toBe(StepCategory.Ai);
+    });
+  });
+
+  describe('schemas', () => {
+    it('has inputSchema defined', () => {
+      expect(generateStepPublicDefinition.inputSchema).toBeDefined();
+    });
+
+    it('has outputSchema defined', () => {
+      expect(generateStepPublicDefinition.outputSchema).toBeDefined();
+    });
+  });
+
+  describe('documentation', () => {
+    it('is defined', () => {
+      expect(generateStepPublicDefinition.documentation).toBeDefined();
+    });
+
+    it('has details defined', () => {
+      expect(generateStepPublicDefinition.documentation?.details).toBeDefined();
+    });
+
+    it('has details as a string', () => {
+      expect(typeof generateStepPublicDefinition.documentation?.details).toBe('string');
+    });
+
+    it('has non-empty details', () => {
+      expect(generateStepPublicDefinition.documentation?.details?.length).toBeGreaterThan(0);
+    });
+
+    it('has examples defined', () => {
+      expect(generateStepPublicDefinition.documentation?.examples).toBeDefined();
+    });
+
+    it('has examples as an array', () => {
+      expect(Array.isArray(generateStepPublicDefinition.documentation?.examples)).toBe(true);
+    });
+
+    it('has at least one example', () => {
+      expect(generateStepPublicDefinition.documentation?.examples?.length).toBeGreaterThan(0);
+    });
+
+    it('has at least 3 examples', () => {
+      expect(generateStepPublicDefinition.documentation?.examples?.length).toBeGreaterThanOrEqual(
+        3
+      );
+    });
+  });
+
+  describe('documentation examples', () => {
+    const examples = generateStepPublicDefinition.documentation?.examples ?? [];
+
+    it.each(examples.map((example, index) => [index, example]))(
+      'example %i contains YAML code block',
+      (_index, example) => {
+        expect(example).toContain('```yaml');
+      }
+    );
+
+    it.each(examples.map((example, index) => [index, example]))(
+      'example %i closes YAML code block',
+      (_index, example) => {
+        expect(example).toContain('```');
+      }
+    );
+
+    it.each(examples.map((example, index) => [index, example]))(
+      'example %i references the correct step type',
+      (_index, example) => {
+        expect(example).toContain('attack-discovery.generate');
+      }
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/public/step_types/generate_step.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/step_types/generate_step.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import type { PublicStepDefinition } from '@kbn/workflows-extensions/public';
+import {
+  GenerateStepCommonDefinition,
+  GenerateStepTypeId,
+} from '../../common/step_types/generate_step';
+
+export const generateStepPublicDefinition: PublicStepDefinition = {
+  ...GenerateStepCommonDefinition,
+
+  icon: React.lazy(() =>
+    import('@elastic/eui/es/components/icon/assets/sparkles').then(({ icon }) => ({
+      default: icon,
+    }))
+  ),
+
+  documentation: {
+    details: i18n.translate('xpack.discoveries.workflowSteps.generate.documentation.details', {
+      defaultMessage: `This step invokes an LLM-powered graph to analyze security alerts and generate attack discoveries or defend insights.
+
+**Recommended Configuration:**
+- Set a timeout of 10 minutes to allow sufficient time for complex analysis
+- Use {templateSyntax} to pass alerts from the retrieval step
+- The {sizeParam} parameter controls the maximum number of discoveries generated
+
+**Performance Notes:**
+- Generation time varies based on alert count and complexity
+- Typical execution ranges from 15 seconds to 5 minutes
+- Complex scenarios may require up to 10 minutes
+
+**Input Requirements:**
+- {alertsField}: Array of security alerts to analyze
+- {apiConfigField}: Connector configuration with action_type_id and connector_id
+- {typeField}: Either 'attack_discovery' or 'defend_insights'
+- {replacementsField}: Optional anonymization replacements map
+- {additionalContextField}: Optional free-form text appended to the LLM prompt`,
+      values: {
+        additionalContextField: '`additional_context`',
+        templateSyntax: '`${{ steps.retrieve_alerts.output.alerts }}`',
+        sizeParam: '`size`',
+        alertsField: '`alerts`',
+        apiConfigField: '`api_config`',
+        typeField: '`type`',
+        replacementsField: '`replacements`',
+      },
+    }),
+    examples: [
+      `## Basic generation with timeout
+\`\`\`yaml
+- name: generate_discoveries
+  type: ${GenerateStepTypeId}
+  timeout: '10m'  # Recommended: 10 minutes for complex analysis
+  with:
+    type: attack_discovery
+    alerts: \${{ steps.retrieve_alerts.output.alerts }}
+    api_config:
+      action_type_id: '.gemini'
+      connector_id: my-connector
+      model: 'gemini-2.0-flash-exp'
+\`\`\``,
+
+      `## With size limit and replacements
+\`\`\`yaml
+- name: generate_discoveries
+  type: ${GenerateStepTypeId}
+  timeout: '10m'
+  with:
+    type: attack_discovery
+    alerts: \${{ steps.retrieve_alerts.output.alerts }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    replacements: \${{ steps.retrieve_alerts.output.replacements }}
+    size: 10  # Maximum number of discoveries to generate
+\`\`\``,
+
+      `## Full pipeline example
+\`\`\`yaml
+- name: retrieve_alerts
+  type: attack-discovery.defaultAlertRetrieval
+  with:
+    alerts_index_pattern: '.alerts-security.alerts-default'
+    size: 100
+    start: 'now-24h'
+    end: 'now'
+
+- name: generate_discoveries
+  type: ${GenerateStepTypeId}
+  timeout: '10m'
+  with:
+    type: attack_discovery
+    alerts: \${{ steps.retrieve_alerts.output.alerts }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    replacements: \${{ steps.retrieve_alerts.output.replacements }}
+
+- name: validate_discoveries
+  type: attack-discovery.defaultValidation
+  with:
+    attack_discoveries: \${{ steps.generate_discoveries.output.attack_discoveries }}
+    anonymized_alerts: \${{ steps.retrieve_alerts.output.anonymized_alerts }}
+\`\`\``,
+
+      `## With additional context for focused analysis
+\`\`\`yaml
+- name: generate_discoveries
+  type: ${GenerateStepTypeId}
+  timeout: '10m'
+  with:
+    type: attack_discovery
+    alerts: \${{ steps.retrieve_alerts.output.alerts }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    additional_context: >
+      Focus on lateral movement and privilege escalation techniques.
+      The environment uses Active Directory for identity management.
+\`\`\``,
+
+      `## Defend insights generation
+\`\`\`yaml
+- name: generate_insights
+  type: ${GenerateStepTypeId}
+  timeout: '10m'
+  with:
+    type: defend_insights
+    alerts: \${{ steps.retrieve_alerts.output.alerts }}
+    api_config:
+      action_type_id: '.gen-ai'
+      connector_id: my-openai-connector
+\`\`\``,
+    ],
+  },
+};

--- a/x-pack/solutions/security/plugins/discoveries/public/step_types/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/step_types/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { defaultAlertRetrievalStepPublicDefinition } from './default_alert_retrieval_step';
+export { defaultValidationStepPublicDefinition } from './default_validation_step';
+export { generateStepPublicDefinition } from './generate_step';
+export { persistDiscoveriesStepPublicDefinition } from './persist_discoveries_step';
+export { runStepPublicDefinition } from './run_step';

--- a/x-pack/solutions/security/plugins/discoveries/public/step_types/persist_discoveries_step.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/step_types/persist_discoveries_step.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { StepCategory } from '@kbn/workflows';
+import { persistDiscoveriesStepPublicDefinition } from './persist_discoveries_step';
+import { PersistDiscoveriesStepTypeId } from '../../common/step_types/persist_discoveries_step';
+
+describe('persistDiscoveriesStepPublicDefinition', () => {
+  describe('id', () => {
+    it('returns the correct id', () => {
+      expect(persistDiscoveriesStepPublicDefinition.id).toBe(PersistDiscoveriesStepTypeId);
+    });
+
+    it('returns attack-discovery.persistDiscoveries', () => {
+      expect(persistDiscoveriesStepPublicDefinition.id).toBe('attack-discovery.persistDiscoveries');
+    });
+  });
+
+  describe('label', () => {
+    it('is defined', () => {
+      expect(persistDiscoveriesStepPublicDefinition.label).toBeDefined();
+    });
+
+    it('is a string', () => {
+      expect(typeof persistDiscoveriesStepPublicDefinition.label).toBe('string');
+    });
+
+    it('is not empty', () => {
+      expect(persistDiscoveriesStepPublicDefinition.label.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('description', () => {
+    it('is defined', () => {
+      expect(persistDiscoveriesStepPublicDefinition.description).toBeDefined();
+    });
+
+    it('is a string', () => {
+      expect(typeof persistDiscoveriesStepPublicDefinition.description).toBe('string');
+    });
+
+    it('is not empty', () => {
+      expect(persistDiscoveriesStepPublicDefinition.description?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('icon', () => {
+    it('is defined', () => {
+      expect(persistDiscoveriesStepPublicDefinition.icon).toBeDefined();
+    });
+  });
+
+  describe('category', () => {
+    it('is set to Kibana', () => {
+      expect(persistDiscoveriesStepPublicDefinition.category).toBe(StepCategory.Kibana);
+    });
+  });
+
+  describe('schemas', () => {
+    it('has inputSchema defined', () => {
+      expect(persistDiscoveriesStepPublicDefinition.inputSchema).toBeDefined();
+    });
+
+    it('has outputSchema defined', () => {
+      expect(persistDiscoveriesStepPublicDefinition.outputSchema).toBeDefined();
+    });
+  });
+
+  describe('documentation', () => {
+    it('is defined', () => {
+      expect(persistDiscoveriesStepPublicDefinition.documentation).toBeDefined();
+    });
+
+    it('has details defined', () => {
+      expect(persistDiscoveriesStepPublicDefinition.documentation?.details).toBeDefined();
+    });
+
+    it('has details as a string', () => {
+      expect(typeof persistDiscoveriesStepPublicDefinition.documentation?.details).toBe('string');
+    });
+
+    it('has non-empty details', () => {
+      expect(persistDiscoveriesStepPublicDefinition.documentation?.details?.length).toBeGreaterThan(
+        0
+      );
+    });
+
+    it('has examples defined', () => {
+      expect(persistDiscoveriesStepPublicDefinition.documentation?.examples).toBeDefined();
+    });
+
+    it('has examples as an array', () => {
+      expect(Array.isArray(persistDiscoveriesStepPublicDefinition.documentation?.examples)).toBe(
+        true
+      );
+    });
+
+    it('has at least one example', () => {
+      expect(
+        persistDiscoveriesStepPublicDefinition.documentation?.examples?.length
+      ).toBeGreaterThan(0);
+    });
+
+    it('has at least 3 examples', () => {
+      expect(
+        persistDiscoveriesStepPublicDefinition.documentation?.examples?.length
+      ).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('documentation examples', () => {
+    const examples = persistDiscoveriesStepPublicDefinition.documentation?.examples ?? [];
+
+    it.each(examples.map((example, index) => [index, example]))(
+      'example %i contains YAML code block',
+      (_index, example) => {
+        expect(example).toContain('```yaml');
+      }
+    );
+
+    it.each(examples.map((example, index) => [index, example]))(
+      'example %i closes YAML code block',
+      (_index, example) => {
+        expect(example).toContain('```');
+      }
+    );
+
+    it.each(examples.map((example, index) => [index, example]))(
+      'example %i references the correct step type',
+      (_index, example) => {
+        expect(example).toContain('attack-discovery.persistDiscoveries');
+      }
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/public/step_types/persist_discoveries_step.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/step_types/persist_discoveries_step.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import type { PublicStepDefinition } from '@kbn/workflows-extensions/public';
+import { DefaultValidationStepTypeId } from '../../common/step_types/default_validation_step';
+import {
+  PersistDiscoveriesStepCommonDefinition,
+  PersistDiscoveriesStepTypeId,
+} from '../../common/step_types/persist_discoveries_step';
+
+export const persistDiscoveriesStepPublicDefinition: PublicStepDefinition = {
+  ...PersistDiscoveriesStepCommonDefinition,
+
+  icon: React.lazy(() =>
+    import('@elastic/eui/es/components/icon/assets/save').then(({ icon }) => ({
+      default: icon,
+    }))
+  ),
+
+  documentation: {
+    details: i18n.translate(
+      'xpack.discoveries.workflowSteps.persistDiscoveries.documentation.details',
+      {
+        defaultMessage: `This step writes Attack Discoveries as alerts to Elasticsearch, making them visible in the Attack Discovery UI. Use the {validationStep} step beforehand to filter hallucinated references and remove duplicates.
+
+**Key Features:**
+- Writes discoveries to the Attack Discovery alerts index
+- Deduplicates discoveries before persisting
+- De-anonymizes fields using replacement map (optional)
+- Renders markdown fields for display (optional)
+- Links discoveries to the generation execution
+
+**Configuration:**
+- {attackDiscoveries}: Array of validated discoveries to persist (typically from the {validationStep} step output)
+- {anonymizedAlerts}: Original anonymized alerts for context
+- {replacements}: Map for de-anonymizing sensitive fields
+- {apiConfig}: Connector configuration used for generation
+- {connectorName}: Display name of the connector
+- {generationUuid}: Execution UUID linking discoveries to generation event
+- {alertsContextCount}: Number of alerts analyzed
+- {enableFieldRendering}: Render markdown fields (default: true)
+- {withReplacements}: Apply de-anonymization (default: false)
+
+**Output:**
+Returns persisted discoveries from the Attack Discovery alerts index.`,
+        values: {
+          alertsContextCount: '`alerts_context_count`',
+          anonymizedAlerts: '`anonymized_alerts`',
+          apiConfig: '`api_config`',
+          attackDiscoveries: '`attack_discoveries`',
+          connectorName: '`connector_name`',
+          enableFieldRendering: '`enable_field_rendering`',
+          generationUuid: '`generation_uuid`',
+          replacements: '`replacements`',
+          validationStep: '`attack-discovery.defaultValidation`',
+          withReplacements: '`with_replacements`',
+        },
+      }
+    ),
+    examples: [
+      `## Basic persistence (after validation)
+\`\`\`yaml
+- name: persist_discoveries
+  type: ${PersistDiscoveriesStepTypeId}
+  with:
+    attack_discoveries: \${{ steps.validate_discoveries.output.validated_discoveries }}
+    anonymized_alerts: \${{ steps.retrieve_alerts.output.anonymized_alerts }}
+    replacements: \${{ steps.generate_discoveries.output.replacements }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    connector_name: \${{ steps.retrieve_alerts.output.connector_name }}
+    generation_uuid: \${{ steps.generate_discoveries.output.execution_uuid }}
+    alerts_context_count: \${{ steps.retrieve_alerts.output.alerts_context_count }}
+\`\`\``,
+
+      `## Validate then persist
+\`\`\`yaml
+- name: validate_discoveries
+  type: ${DefaultValidationStepTypeId}
+  with:
+    attack_discoveries: \${{ steps.generate_discoveries.output.attack_discoveries }}
+    anonymized_alerts: \${{ steps.retrieve_alerts.output.anonymized_alerts }}
+    replacements: \${{ steps.generate_discoveries.output.replacements }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    connector_name: \${{ steps.retrieve_alerts.output.connector_name }}
+    generation_uuid: \${{ steps.generate_discoveries.output.execution_uuid }}
+    alerts_context_count: \${{ steps.retrieve_alerts.output.alerts_context_count }}
+
+- name: persist_discoveries
+  type: ${PersistDiscoveriesStepTypeId}
+  with:
+    attack_discoveries: \${{ steps.validate_discoveries.output.validated_discoveries }}
+    anonymized_alerts: \${{ steps.retrieve_alerts.output.anonymized_alerts }}
+    replacements: \${{ steps.generate_discoveries.output.replacements }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    connector_name: \${{ steps.retrieve_alerts.output.connector_name }}
+    generation_uuid: \${{ steps.generate_discoveries.output.execution_uuid }}
+    alerts_context_count: \${{ steps.retrieve_alerts.output.alerts_context_count }}
+\`\`\``,
+
+      `## Full end-to-end pipeline: retrieve, generate, validate, persist
+\`\`\`yaml
+- name: retrieve_alerts
+  type: attack-discovery.defaultAlertRetrieval
+  timeout: '5m'
+  with:
+    alerts_index_pattern: '.alerts-security.alerts-default'
+    size: 100
+    start: 'now-24h'
+    end: 'now'
+    api_config:
+      action_type_id: '.gen-ai'
+      connector_id: my-connector
+
+- name: generate_discoveries
+  type: attack-discovery.generate
+  timeout: '10m'
+  with:
+    type: attack_discovery
+    alerts: \${{ steps.retrieve_alerts.output.alerts }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    replacements: \${{ steps.retrieve_alerts.output.replacements }}
+
+- name: validate_discoveries
+  type: ${DefaultValidationStepTypeId}
+  with:
+    attack_discoveries: \${{ steps.generate_discoveries.output.attack_discoveries }}
+    anonymized_alerts: \${{ steps.retrieve_alerts.output.anonymized_alerts }}
+    replacements: \${{ steps.generate_discoveries.output.replacements }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    connector_name: \${{ steps.retrieve_alerts.output.connector_name }}
+    generation_uuid: \${{ steps.generate_discoveries.output.execution_uuid }}
+    alerts_context_count: \${{ steps.retrieve_alerts.output.alerts_context_count }}
+
+- name: persist_discoveries
+  type: ${PersistDiscoveriesStepTypeId}
+  with:
+    attack_discoveries: \${{ steps.validate_discoveries.output.validated_discoveries }}
+    anonymized_alerts: \${{ steps.retrieve_alerts.output.anonymized_alerts }}
+    replacements: \${{ steps.generate_discoveries.output.replacements }}
+    api_config: \${{ steps.retrieve_alerts.output.api_config }}
+    connector_name: \${{ steps.retrieve_alerts.output.connector_name }}
+    generation_uuid: \${{ steps.generate_discoveries.output.execution_uuid }}
+    alerts_context_count: \${{ steps.retrieve_alerts.output.alerts_context_count }}
+    enable_field_rendering: true
+    with_replacements: true
+\`\`\``,
+    ],
+  },
+};

--- a/x-pack/solutions/security/plugins/discoveries/public/step_types/run_step.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/step_types/run_step.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import type { PublicStepDefinition } from '@kbn/workflows-extensions/public';
+import { RunStepCommonDefinition, RunStepTypeId } from '../../common/step_types/run_step';
+
+export const runStepPublicDefinition: PublicStepDefinition = {
+  ...RunStepCommonDefinition,
+
+  icon: React.lazy(() =>
+    import('@elastic/eui/es/components/icon/assets/sparkles').then(({ icon }) => ({
+      default: icon,
+    }))
+  ),
+
+  documentation: {
+    details: i18n.translate('xpack.discoveries.workflowSteps.run.documentation.details', {
+      defaultMessage: `High-level entry point for Attack Discovery. Orchestrates alert retrieval, LLM generation, and validation in a single step.
+
+**Modes:**
+- {syncMode}: Waits for the full pipeline and returns discoveries inline (first synchronous AD entry point)
+- {asyncMode}: Fires the pipeline and immediately returns {executionUuidField}
+
+**Security:**
+- The {replacementsField} map is never included in the output
+
+**Minimal Configuration:**
+- Only {connectorIdField} is required — all other fields are optional with sensible defaults
+
+**Performance Notes:**
+- Sync mode may take several minutes depending on alert volume and LLM latency
+- Async mode returns immediately; poll via execution_uuid for results`,
+      values: {
+        asyncMode: "`mode: 'async'`",
+        connectorIdField: '`connector_id`',
+        executionUuidField: '`execution_uuid`',
+        replacementsField: '`replacements`',
+        syncMode: "`mode: 'sync'`",
+      },
+    }),
+    examples: [
+      `## Minimal sync run (connector_id only)
+\`\`\`yaml
+- name: run_attack_discovery
+  type: ${RunStepTypeId}
+  timeout: '10m'
+  with:
+    connector_id: my-connector
+\`\`\``,
+
+      `## Async run (fire-and-forget)
+\`\`\`yaml
+- name: run_attack_discovery
+  type: ${RunStepTypeId}
+  with:
+    connector_id: my-connector
+    mode: async
+\`\`\``,
+
+      `## Sync run with time range and size
+\`\`\`yaml
+- name: run_attack_discovery
+  type: ${RunStepTypeId}
+  timeout: '10m'
+  with:
+    connector_id: my-connector
+    size: 50
+    start: 'now-24h'
+    end: 'now'
+\`\`\``,
+
+      `## With ES|QL alert retrieval
+\`\`\`yaml
+- name: run_attack_discovery
+  type: ${RunStepTypeId}
+  timeout: '10m'
+  with:
+    connector_id: my-connector
+    alert_retrieval_mode: esql
+    esql_query: 'FROM .alerts-security.alerts-default | WHERE kibana.alert.severity == "critical" | LIMIT 50'
+\`\`\``,
+
+      `## With pre-retrieved alerts
+\`\`\`yaml
+- name: run_attack_discovery
+  type: ${RunStepTypeId}
+  timeout: '10m'
+  with:
+    connector_id: my-connector
+    alerts: \${{ steps.my_retrieval_step.output.alerts }}
+\`\`\``,
+
+      `## With additional context for focused analysis
+\`\`\`yaml
+- name: run_attack_discovery
+  type: ${RunStepTypeId}
+  timeout: '10m'
+  with:
+    connector_id: my-connector
+    additional_context: >
+      Focus on lateral movement and privilege escalation techniques.
+      The environment uses Active Directory for identity management.
+\`\`\``,
+    ],
+  },
+};

--- a/x-pack/solutions/security/plugins/discoveries/public/types.ts
+++ b/x-pack/solutions/security/plugins/discoveries/public/types.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
+
+export interface DiscoveriesPublicPluginSetupDeps {
+  workflowsExtensions: WorkflowsExtensionsPublicPluginSetup;
+}
+
+export interface DiscoveriesPublicPluginStartDeps {
+  agentBuilder?: AgentBuilderPluginStart;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DiscoveriesPublicPluginSetup {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DiscoveriesPublicPluginStart {}

--- a/x-pack/solutions/security/plugins/discoveries/server/agent_builder/attachments/diagnostic_report/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/agent_builder/attachments/diagnostic_report/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
+
+// Placeholder — real implementation added in PR 8
+export const createDiagnosticReportAttachmentType = (): AttachmentTypeDefinition => ({
+  format: async () => ({}),
+  id: 'attack-discovery:diagnostic-report',
+  validate: async () => ({ data: undefined, valid: true as const }),
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/index.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { PluginConfigDescriptor, PluginInitializerContext } from '@kbn/core/server';
+import { DiscoveriesPlugin } from './plugin';
+
+export type { DiscoveriesPluginSetup, DiscoveriesPluginStart } from './types';
+
+/**
+ * Default timeout for LLM connector calls in milliseconds.
+ * This controls how long we wait for the LLM to respond before timing out.
+ * Default: 10 minutes
+ */
+export const DEFAULT_CONNECTOR_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * Default timeout for the generation route handler in milliseconds.
+ * This controls how long the HTTP route can remain open before timing out.
+ * Default: 10 minutes
+ */
+export const DEFAULT_ROUTE_HANDLER_TIMEOUT_MS = 10 * 60 * 1000;
+
+// Config schema is required for all plugins
+const configSchema = schema.object({
+  connectorTimeout: schema.number({ defaultValue: DEFAULT_CONNECTOR_TIMEOUT_MS }),
+  enabled: schema.boolean({ defaultValue: true }),
+  langSmithApiKey: schema.maybe(schema.string()),
+  langSmithProject: schema.maybe(schema.string()),
+});
+
+export const config: PluginConfigDescriptor = {
+  schema: configSchema,
+};
+
+export const plugin = (context: PluginInitializerContext) => {
+  const logger = context.logger.get();
+  logger.warn('🟢 discoveries: Plugin factory function called - creating plugin instance');
+  return new DiscoveriesPlugin(context);
+};

--- a/x-pack/solutions/security/plugins/discoveries/server/lib/schedules/workflow_executor/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/lib/schedules/workflow_executor/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Placeholder — real implementation added in PR 10
+export const workflowExecutor = async (
+  _params: unknown
+): Promise<{ state: Record<string, never> }> => ({
+  state: {},
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/plugin.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/plugin.test.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { coreMock } from '@kbn/core/server/mocks';
+import type { AttackDiscoveryExecutorOptions } from '@kbn/attack-discovery-schedules-common';
+
+import { DiscoveriesPlugin } from './plugin';
+import type { DiscoveriesPluginSetupDeps } from './types';
+
+jest.mock('@kbn/discoveries/impl/attack_discovery/alert_fields', () => ({
+  ATTACK_DISCOVERY_ALERTS_CONTEXT: 'siem.security.attack.discovery',
+  attackDiscoveryAlertFieldMap: {},
+}));
+
+jest.mock('./lib/schedules/workflow_executor', () => ({
+  workflowExecutor: jest.fn().mockResolvedValue({ state: {} }),
+}));
+
+jest.mock('./routes', () => ({
+  registerRoutes: jest.fn(),
+}));
+
+jest.mock('./lib/workflow_initialization', () => ({
+  createWorkflowInitializationService: jest.fn().mockReturnValue({
+    ensureWorkflowsForSpace: jest.fn(),
+    verifyAndRepairWorkflows: jest.fn(),
+  }),
+}));
+
+jest.mock('./skills/register_skills', () => ({
+  registerSkills: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('./workflows/register_workflow_steps', () => ({
+  registerWorkflowSteps: jest.fn().mockReturnValue({ failedSteps: [] }),
+}));
+
+jest.mock('@kbn/alerting-plugin/common', () => ({
+  mappingFromFieldMap: jest.fn().mockReturnValue({}),
+}));
+
+const { workflowExecutor } = jest.requireMock('./lib/schedules/workflow_executor');
+
+const createMockRuleRegistry = () => ({
+  ruleDataService: {
+    initializeIndex: jest.fn().mockReturnValue({
+      getReader: jest.fn(),
+      getWriter: jest.fn(),
+    }),
+  },
+});
+
+const createMockEventLog = () => ({
+  getIndexPattern: jest.fn().mockReturnValue('.kibana-event-log-*'),
+  getLogger: jest.fn().mockReturnValue({ logEvent: jest.fn() }),
+  registerProviderActions: jest.fn(),
+  registerSavedObjectProvider: jest.fn(),
+  isLoggingEntries: jest.fn().mockReturnValue(true),
+  isIndexingEntries: jest.fn().mockReturnValue(true),
+});
+
+const createMockWorkflowsExtensions = () => ({
+  registerStepType: jest.fn(),
+});
+
+const createMockElasticAssistant = () => ({
+  actions: {} as never,
+  registerAttackDiscoveryWorkflowExecutor: jest.fn(),
+});
+
+const createMockActions = () => ({
+  registerType: jest.fn(),
+});
+
+const createMockAlerting = () => ({
+  registerConnectorAdapter: jest.fn(),
+});
+
+const createPluginSetupDeps = (
+  overrides: Partial<DiscoveriesPluginSetupDeps> = {}
+): DiscoveriesPluginSetupDeps => ({
+  actions: createMockActions() as unknown as DiscoveriesPluginSetupDeps['actions'],
+  alerting: createMockAlerting() as unknown as DiscoveriesPluginSetupDeps['alerting'],
+  eventLog: createMockEventLog() as unknown as DiscoveriesPluginSetupDeps['eventLog'],
+  ruleRegistry: createMockRuleRegistry() as unknown as DiscoveriesPluginSetupDeps['ruleRegistry'],
+  workflowsExtensions:
+    createMockWorkflowsExtensions() as unknown as DiscoveriesPluginSetupDeps['workflowsExtensions'],
+  ...overrides,
+});
+
+const createPluginInitializerContext = () =>
+  coreMock.createPluginInitializerContext({
+    enabled: true,
+  });
+
+describe('DiscoveriesPlugin', () => {
+  describe('setup', () => {
+    describe('workflow executor registration', () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('registers the workflow executor when elasticAssistant is available', () => {
+        const mockElasticAssistant = createMockElasticAssistant();
+        const context = createPluginInitializerContext();
+        const plugin = new DiscoveriesPlugin(context);
+
+        const coreSetup = coreMock.createSetup();
+        const deps = createPluginSetupDeps({
+          elasticAssistant: mockElasticAssistant,
+        });
+
+        plugin.setup(coreSetup, deps);
+
+        expect(mockElasticAssistant.registerAttackDiscoveryWorkflowExecutor).toHaveBeenCalledTimes(
+          1
+        );
+        expect(mockElasticAssistant.registerAttackDiscoveryWorkflowExecutor).toHaveBeenCalledWith(
+          expect.any(Function)
+        );
+      });
+
+      it('does not throw when elasticAssistant is not available', () => {
+        const context = createPluginInitializerContext();
+        const plugin = new DiscoveriesPlugin(context);
+
+        const coreSetup = coreMock.createSetup();
+        const deps = createPluginSetupDeps();
+
+        expect(() => plugin.setup(coreSetup, deps)).not.toThrow();
+      });
+
+      it('invokes workflowExecutor when the registered factory is called', async () => {
+        const mockElasticAssistant = createMockElasticAssistant();
+        const context = createPluginInitializerContext();
+        const plugin = new DiscoveriesPlugin(context);
+
+        const coreSetup = coreMock.createSetup();
+        const deps = createPluginSetupDeps({
+          elasticAssistant: mockElasticAssistant,
+        });
+
+        plugin.setup(coreSetup, deps);
+
+        const factory =
+          mockElasticAssistant.registerAttackDiscoveryWorkflowExecutor.mock.calls[0][0];
+
+        const mockOptions = {
+          params: { alertsIndexPattern: '.alerts-*', apiConfig: {} },
+          rule: { id: 'rule-1' },
+          services: { alertsClient: {} },
+          spaceId: 'default',
+        } as unknown as AttackDiscoveryExecutorOptions;
+
+        const result = await factory(mockOptions);
+
+        expect(workflowExecutor).toHaveBeenCalledTimes(1);
+        expect(workflowExecutor).toHaveBeenCalledWith({
+          deps: expect.objectContaining({
+            getEventLogIndex: expect.any(Function),
+            getEventLogger: expect.any(Function),
+            getStartServices: expect.any(Function),
+            logger: expect.anything(),
+            request: expect.objectContaining({
+              headers: expect.any(Object),
+            }),
+            workflowInitService: expect.objectContaining({
+              ensureWorkflowsForSpace: expect.any(Function),
+            }),
+          }),
+          options: mockOptions,
+        });
+
+        expect(result).toEqual({ state: {} });
+      });
+
+      it('creates a fake request with authorization extracted from the scoped cluster client transport', async () => {
+        const mockElasticAssistant = createMockElasticAssistant();
+        const context = createPluginInitializerContext();
+        const plugin = new DiscoveriesPlugin(context);
+
+        const coreSetup = coreMock.createSetup();
+        const deps = createPluginSetupDeps({
+          elasticAssistant: mockElasticAssistant,
+        });
+
+        plugin.setup(coreSetup, deps);
+
+        const factory =
+          mockElasticAssistant.registerAttackDiscoveryWorkflowExecutor.mock.calls[0][0];
+
+        const mockOptions = {
+          executionId: 'exec-1',
+          params: { alertsIndexPattern: '.alerts-*', apiConfig: {} },
+          rule: { id: 'rule-1' },
+          services: {
+            alertsClient: {},
+            scopedClusterClient: {
+              asCurrentUser: {
+                transport: {
+                  headers: { authorization: 'ApiKey dGVzdC1lbmNvZGVk' },
+                },
+              },
+            },
+          },
+          spaceId: 'default',
+        } as unknown as AttackDiscoveryExecutorOptions;
+
+        await factory(mockOptions);
+
+        const passedRequest = workflowExecutor.mock.calls[0][0].deps.request;
+        expect(passedRequest.headers).toEqual(
+          expect.objectContaining({
+            authorization: 'ApiKey dGVzdC1lbmNvZGVk',
+          })
+        );
+      });
+
+      it('falls back to empty headers when transport has no authorization header', async () => {
+        const mockElasticAssistant = createMockElasticAssistant();
+        const context = createPluginInitializerContext();
+        const plugin = new DiscoveriesPlugin(context);
+
+        const coreSetup = coreMock.createSetup();
+        const deps = createPluginSetupDeps({
+          elasticAssistant: mockElasticAssistant,
+        });
+
+        plugin.setup(coreSetup, deps);
+
+        const factory =
+          mockElasticAssistant.registerAttackDiscoveryWorkflowExecutor.mock.calls[0][0];
+
+        const mockOptions = {
+          executionId: 'exec-1',
+          params: { alertsIndexPattern: '.alerts-*', apiConfig: {} },
+          rule: { id: 'rule-1' },
+          services: {
+            alertsClient: {},
+            scopedClusterClient: {
+              asCurrentUser: {
+                transport: { headers: {} },
+              },
+            },
+          },
+          spaceId: 'default',
+        } as unknown as AttackDiscoveryExecutorOptions;
+
+        await factory(mockOptions);
+
+        expect(workflowExecutor).toHaveBeenCalledTimes(1);
+        const passedRequest = workflowExecutor.mock.calls[0][0].deps.request;
+        expect(passedRequest.headers.authorization).toBeUndefined();
+      });
+
+      it('creates a new request for each factory invocation', async () => {
+        const mockElasticAssistant = createMockElasticAssistant();
+        const context = createPluginInitializerContext();
+        const plugin = new DiscoveriesPlugin(context);
+
+        const coreSetup = coreMock.createSetup();
+        const deps = createPluginSetupDeps({
+          elasticAssistant: mockElasticAssistant,
+        });
+
+        plugin.setup(coreSetup, deps);
+
+        const factory =
+          mockElasticAssistant.registerAttackDiscoveryWorkflowExecutor.mock.calls[0][0];
+
+        const mockOptions = {
+          params: {},
+          rule: { id: 'rule-1' },
+          services: {},
+          spaceId: 'default',
+        } as unknown as AttackDiscoveryExecutorOptions;
+
+        await factory(mockOptions);
+        await factory(mockOptions);
+
+        const firstRequest = workflowExecutor.mock.calls[0][0].deps.request;
+        const secondRequest = workflowExecutor.mock.calls[1][0].deps.request;
+
+        expect(firstRequest).not.toBe(secondRequest);
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/plugin.ts
@@ -1,0 +1,327 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  AnalyticsServiceSetup,
+  CoreSetup,
+  CoreStart,
+  IScopedClusterClient,
+  Logger,
+  Plugin,
+  PluginInitializerContext,
+} from '@kbn/core/server';
+import type { FakeRawRequest } from '@kbn/core-http-server';
+import { kibanaRequestFactory } from '@kbn/core-http-server-utils';
+import { ECS_COMPONENT_TEMPLATE_NAME } from '@kbn/alerting-plugin/server';
+import { mappingFromFieldMap } from '@kbn/alerting-plugin/common';
+import type { IRuleDataClient, IndexOptions } from '@kbn/rule-registry-plugin/server';
+import { Dataset } from '@kbn/rule-registry-plugin/server';
+import { ATTACK_DISCOVERY_SCHEDULES_CONSUMER_ID } from '@kbn/elastic-assistant-common';
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+
+import {
+  ATTACK_DISCOVERY_ALERTS_CONTEXT,
+  attackDiscoveryAlertFieldMap,
+} from '@kbn/discoveries/impl/attack_discovery/alert_fields';
+import {
+  ATTACK_DISCOVERY_MISCONFIGURATION_EVENT,
+  ATTACK_DISCOVERY_SCHEDULE_ACTION_EVENT,
+  ATTACK_DISCOVERY_STEP_FAILURE_EVENT,
+} from '@kbn/discoveries/impl/lib/telemetry/event_based_telemetry';
+import { reportMisconfiguration } from '@kbn/discoveries/impl/lib/telemetry/report_misconfiguration';
+import { DEFAULT_CONNECTOR_TIMEOUT_MS } from '.';
+import { logStartupHealthCheck } from './lib/startup_health_check';
+import { workflowExecutor } from './lib/schedules/workflow_executor';
+import { registerRoutes } from './routes';
+import { createWorkflowInitializationService } from './lib/workflow_initialization';
+import { createDiagnosticReportAttachmentType } from './agent_builder/attachments/diagnostic_report';
+import { registerSkills } from './skills/register_skills';
+import type {
+  DiscoveriesPluginSetup,
+  DiscoveriesPluginSetupDeps,
+  DiscoveriesPluginStart,
+  DiscoveriesPluginStartDeps,
+} from './types';
+import {
+  registerWorkflowSteps,
+  type StepRegistrationResult,
+} from './workflows/register_workflow_steps';
+
+interface DiscoveriesConfig {
+  connectorTimeout?: number;
+  enabled: boolean;
+  langSmithApiKey?: string;
+  langSmithProject?: string;
+}
+
+/**
+ * Extracts authorization headers from the alerting framework's pre-authenticated
+ * scoped cluster client for use in the workflow execution engine's fake request.
+ *
+ * The alerting framework authenticates rule executors via the rule's stored
+ * API key, but only exposes pre-scoped clients — not the authenticated
+ * KibanaRequest. The workflow execution engine needs an authenticated
+ * KibanaRequest to create its own scoped services, so this function bridges
+ * the gap by extracting the authorization header from the scoped client's
+ * transport layer.
+ */
+const createWorkflowAuthHeaders = async ({
+  executionId,
+  logger,
+  scopedClusterClient,
+}: {
+  executionId: string;
+  logger: Logger;
+  scopedClusterClient: IScopedClusterClient;
+}): Promise<Record<string, string>> => {
+  try {
+    const esClient = scopedClusterClient.asCurrentUser;
+
+    // The scoped ES client's transport stores the authorization header that
+    // the alerting framework derived from the rule's stored API key. We extract
+    // it directly instead of creating a derived API key, which avoids the
+    // "illegal_argument_exception: creating derived api keys requires an
+    // explicit role descriptor" limitation.
+    const transportHeaders: Record<string, string> =
+      (esClient.transport as unknown as { headers: Record<string, string> }).headers ?? {};
+
+    if (transportHeaders.authorization) {
+      return { authorization: transportHeaders.authorization };
+    }
+
+    logger.warn(
+      () => `No authorization header found in scoped client transport for execution ${executionId}`
+    );
+    return {};
+  } catch (error) {
+    logger.warn(
+      () => `Failed to extract auth headers for workflow execution ${executionId}: ${error.message}`
+    );
+
+    return {};
+  }
+};
+
+export class DiscoveriesPlugin
+  implements
+    Plugin<
+      DiscoveriesPluginSetup,
+      DiscoveriesPluginStart,
+      DiscoveriesPluginSetupDeps,
+      DiscoveriesPluginStartDeps
+    >
+{
+  private analytics?: AnalyticsServiceSetup;
+  private readonly config: DiscoveriesConfig;
+  private readonly logger: Logger;
+  private adhocAttackDiscoveryDataClient?: IRuleDataClient;
+  private workflowsManagementApi?: WorkflowsServerPluginSetup['management'];
+  private workflowStepRegistrationResult: StepRegistrationResult = {
+    failedSteps: [],
+    registeredSteps: [],
+  };
+
+  constructor(context: PluginInitializerContext) {
+    this.config = context.config.get<DiscoveriesConfig>();
+    this.logger = context.logger.get();
+  }
+
+  public setup(
+    core: CoreSetup<DiscoveriesPluginStartDeps, DiscoveriesPluginStart>,
+    plugins: DiscoveriesPluginSetupDeps
+  ): DiscoveriesPluginSetup {
+    this.analytics = core.analytics;
+    core.analytics.registerEventType(ATTACK_DISCOVERY_MISCONFIGURATION_EVENT);
+    core.analytics.registerEventType(ATTACK_DISCOVERY_SCHEDULE_ACTION_EVENT);
+    core.analytics.registerEventType(ATTACK_DISCOVERY_STEP_FAILURE_EVENT);
+
+    if (!plugins.ruleRegistry) {
+      // NOTE: `ruleRegistry` is optional in `kibana.jsonc` so this plugin can have a browser-side
+      // component (needed for Workflows UI step schema registration). However, this server plugin
+      // requires `ruleRegistry` to persist Attack Discoveries.
+      this.logger.error(
+        '🔴 discoveries: ruleRegistry plugin is missing. Cannot initialize Attack Discovery persistence or routes.'
+      );
+      throw new Error('discoveries requires ruleRegistry on the server');
+    }
+
+    /**
+     * Initialize the `default` index for ad-hoc generated Attack Discoveries.
+     *
+     * This mirrors what elastic_assistant does, but is owned by this plugin so we have
+     * zero runtime dependency on elastic_assistant.
+     */
+    const ruleDataServiceOptions: IndexOptions = {
+      // IMPORTANT: These values MUST match what elastic_assistant uses to ensure
+      // both plugins read/write to the same index. See elastic_assistant/server/plugin.ts
+      // The resulting index pattern is: .adhoc.alerts-siem.security.attack.discovery-{namespace}
+      feature: ATTACK_DISCOVERY_SCHEDULES_CONSUMER_ID,
+      registrationContext: ATTACK_DISCOVERY_ALERTS_CONTEXT,
+      dataset: Dataset.alerts,
+      additionalPrefix: '.adhoc',
+      componentTemplateRefs: [ECS_COMPONENT_TEMPLATE_NAME],
+      componentTemplates: [
+        {
+          name: 'mappings',
+          mappings: mappingFromFieldMap(attackDiscoveryAlertFieldMap),
+        },
+      ],
+    };
+
+    this.adhocAttackDiscoveryDataClient =
+      plugins.ruleRegistry.ruleDataService.initializeIndex(ruleDataServiceOptions);
+
+    const getStartServices = async () => {
+      const [coreStart, pluginsStart] = await core.getStartServices();
+      return { coreStart, pluginsStart };
+    };
+
+    // Get eventLog pattern
+    const eventLogIndex = plugins.eventLog.getIndexPattern();
+
+    // Create lazy getter for eventLogger
+    const getEventLogger = async () => {
+      return plugins.eventLog.getLogger({
+        event: { provider: 'securitySolution.attackDiscovery' },
+      });
+    };
+
+    const getEventLogIndex = async () => eventLogIndex;
+
+    this.workflowsManagementApi = plugins.workflowsManagement?.management;
+
+    if (this.workflowsManagementApi) {
+      this.logger.debug(
+        () =>
+          'WorkflowsManagement API available (default workflows will be ensured on-demand by routes)'
+      );
+    } else {
+      this.logger.warn('WorkflowsManagement API not available, skipping workflow registration');
+    }
+
+    const workflowInitService = createWorkflowInitializationService({
+      analytics: core.analytics,
+      workflowsManagementApi: this.workflowsManagementApi,
+    });
+
+    this.workflowStepRegistrationResult = registerWorkflowSteps(plugins.workflowsExtensions, {
+      adhocAttackDiscoveryDataClient: this.adhocAttackDiscoveryDataClient,
+      analytics: core.analytics,
+      connectorTimeout: this.config.connectorTimeout ?? DEFAULT_CONNECTOR_TIMEOUT_MS,
+      getEventLogIndex,
+      getEventLogger,
+      getStartServices,
+      langSmithApiKey: this.config.langSmithApiKey,
+      langSmithProject: this.config.langSmithProject,
+      logger: this.logger,
+      workflowInitService,
+      workflowsManagementApi: this.workflowsManagementApi,
+    });
+
+    if (this.workflowStepRegistrationResult.failedSteps.length > 0) {
+      reportMisconfiguration({
+        analytics: core.analytics,
+        logger: this.logger,
+        params: {
+          detail: `Failed to register steps: ${this.workflowStepRegistrationResult.failedSteps
+            .map((s) => `${s.id} (${s.error})`)
+            .join(', ')}`,
+          misconfiguration_type: 'step_registration_failed',
+        },
+      });
+    }
+
+    // Register agent builder attachment types and skills
+    if (plugins.agentBuilder) {
+      plugins.agentBuilder.attachments.registerType(createDiagnosticReportAttachmentType());
+      registerSkills(plugins.agentBuilder, this.logger, {
+        workflowFetcher: this.workflowsManagementApi,
+      }).catch((error) => {
+        this.logger.error(`discoveries: Error registering skills: ${error}`);
+      });
+    } else {
+      this.logger.debug(
+        'discoveries: agentBuilder plugin not available, skipping skill registration'
+      );
+    }
+
+    const router = core.http.createRouter();
+
+    if (!this.adhocAttackDiscoveryDataClient) {
+      throw new Error('Failed to initialize Attack Discovery rule data client');
+    }
+
+    registerRoutes(router, this.logger, {
+      adhocAttackDiscoveryDataClient: this.adhocAttackDiscoveryDataClient,
+      analytics: core.analytics,
+      getEventLogIndex,
+      getEventLogger,
+      getStartServices,
+      workflowInitService,
+      workflowsManagementApi: this.workflowsManagementApi,
+    });
+
+    // Register the workflow executor factory with elastic_assistant so scheduled
+    // rules that carry a workflowConfig can dispatch to this plugin's executor.
+    if (plugins.elasticAssistant) {
+      const logger = this.logger;
+      const workflowsManagementApi = this.workflowsManagementApi;
+
+      const publicBaseUrl = core.http.basePath.publicBaseUrl;
+
+      plugins.elasticAssistant.registerAttackDiscoveryWorkflowExecutor(async (options) => {
+        // The alerting framework authenticates via the rule's stored API key but
+        // only exposes pre-scoped clients — NOT the authenticated KibanaRequest.
+        // The workflow execution engine needs an authenticated KibanaRequest to
+        // create its own scoped services (ES client, actions client, etc.), so we
+        // derive a short-lived API key from the alerting framework's scoped client.
+        const authHeaders = await createWorkflowAuthHeaders({
+          executionId: options.executionId,
+          logger,
+          scopedClusterClient: options.services.scopedClusterClient,
+        });
+
+        const fakeRawRequest: FakeRawRequest = { headers: authHeaders, path: '/' };
+        const request = kibanaRequestFactory(fakeRawRequest);
+
+        return workflowExecutor({
+          deps: {
+            analytics: this.analytics,
+            getEventLogIndex,
+            getEventLogger,
+            getStartServices,
+            logger,
+            publicBaseUrl,
+            request,
+            workflowInitService,
+            workflowsManagementApi,
+          },
+          options,
+        });
+      });
+
+      logger.debug(() => 'Registered workflow executor with elastic_assistant');
+    } else {
+      this.logger.warn('elastic_assistant not available, skipping workflow executor registration');
+    }
+
+    return {};
+  }
+
+  public start(_core: CoreStart, _plugins: DiscoveriesPluginStartDeps): DiscoveriesPluginStart {
+    logStartupHealthCheck({
+      failedStepIds: this.workflowStepRegistrationResult.failedSteps.map((s) => s.id),
+      logger: this.logger,
+      registeredStepCount: this.workflowStepRegistrationResult.registeredSteps.length,
+      workflowsManagementApiAvailable: this.workflowsManagementApi != null,
+    });
+
+    return {};
+  }
+
+  public stop() {}
+}

--- a/x-pack/solutions/security/plugins/discoveries/server/routes/post/validate/helpers/validate_attack_discoveries.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/routes/post/validate/helpers/validate_attack_discoveries.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Placeholder — real implementation added in PR 3
+
+export interface ValidateAttackDiscoveriesResult {
+  duplicates_dropped_count: number;
+  validated_discoveries: unknown[];
+}
+
+export const validateAttackDiscoveries = async (
+  _params: unknown
+): Promise<ValidateAttackDiscoveriesResult> => ({
+  duplicates_dropped_count: 0,
+  validated_discoveries: [],
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/types.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/types.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  PluginSetupContract as ActionsPluginSetup,
+  PluginStartContract as ActionsPluginStart,
+} from '@kbn/actions-plugin/server';
+import type {
+  AgentBuilderPluginSetup,
+  AgentBuilderPluginStart,
+} from '@kbn/agent-builder-plugin/server';
+import type {
+  AlertingApiRequestHandlerContext,
+  AlertingServerSetup,
+} from '@kbn/alerting-plugin/server';
+import type { AttackDiscoveryExecutorOptions } from '@kbn/attack-discovery-schedules-common';
+import type { CustomRequestHandlerContext } from '@kbn/core/server';
+import type { IEventLogService } from '@kbn/event-log-plugin/server';
+import type { InferenceServerStart } from '@kbn/inference-plugin/server';
+import type { RuleRegistryPluginSetupContract } from '@kbn/rule-registry-plugin/server';
+import type { SecurityPluginStart } from '@kbn/security-plugin/server';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+
+export type AttackDiscoveryWorkflowExecutorFactory = (
+  options: AttackDiscoveryExecutorOptions
+) => Promise<{ state: Record<string, never> }>;
+
+/**
+ * Minimal contract for the elastic_assistant plugin setup.
+ * Defined locally to avoid a direct cross-plugin TypeScript reference.
+ */
+export interface ElasticAssistantPluginSetup {
+  registerAttackDiscoveryWorkflowExecutor: (
+    factory: AttackDiscoveryWorkflowExecutorFactory
+  ) => void;
+}
+
+// ElasticAssistantPluginStart will be imported when needed for graph invocation
+export type ElasticAssistantPluginStart = unknown; // TODO: properly type this when we wire up the dependency
+
+export interface DiscoveriesPluginSetupDeps {
+  actions: ActionsPluginSetup;
+  agentBuilder?: AgentBuilderPluginSetup;
+  alerting: AlertingServerSetup;
+  elasticAssistant?: ElasticAssistantPluginSetup;
+  eventLog: IEventLogService;
+  ruleRegistry?: RuleRegistryPluginSetupContract;
+  workflowsExtensions: WorkflowsExtensionsServerPluginSetup;
+  /**
+   * Workflows management API is only exposed on the workflowsManagement *setup* contract.
+   * The workflowsManagement *start* contract is empty.
+   *
+   * We depend on this (optionally) to run and query workflows from server routes.
+   */
+  workflowsManagement?: WorkflowsServerPluginSetup;
+}
+
+export interface DiscoveriesPluginStartDeps {
+  actions: ActionsPluginStart;
+  agentBuilder?: AgentBuilderPluginStart;
+  elasticAssistant?: ElasticAssistantPluginStart;
+  inference?: InferenceServerStart;
+  security: SecurityPluginStart;
+  spaces?: SpacesPluginStart;
+}
+
+export type DiscoveriesRequestHandlerContext = CustomRequestHandlerContext<{
+  alerting: AlertingApiRequestHandlerContext;
+}>;
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DiscoveriesPluginSetup {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DiscoveriesPluginStart {}

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/attack_discovery_custom_validation_example.workflow.yaml
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/attack_discovery_custom_validation_example.workflow.yaml
@@ -1,0 +1,108 @@
+version: '1'
+name: Attack discovery - Custom validation example
+description: |
+  Demonstrates composability with production steps: validate discoveries
+  (hallucination detection + dedup), apply a trivial transformation (sort by
+  title via Liquid filter), then persist to Elasticsearch. Use this as a
+  starting point for custom validation pipelines.
+enabled: true
+tags:
+  - Attack discovery
+  - Security
+  - Example
+  - attackDiscovery:custom_validation_example
+
+triggers:
+  - type: manual
+
+inputs:
+  additionalProperties: false
+  properties:
+    alerts_context_count:
+      description: Number of alerts analyzed
+      type: integer
+    alerts_index_pattern:
+      description: >
+        Elasticsearch index pattern for security alerts. When not provided,
+        defaults to .alerts-security.alerts-<spaceId> using the current
+        Kibana space (via workflow.spaceId).
+      type: string
+    anonymized_alerts:
+      description: Anonymized alerts in Document format
+      items:
+        additionalProperties: true
+        type: object
+      type: array
+    api_config:
+      additionalProperties: false
+      description: LLM API configuration
+      properties:
+        action_type_id:
+          type: string
+        connector_id:
+          type: string
+        model:
+          type: string
+      required:
+        - connector_id
+      type: object
+    attack_discoveries:
+      description: Attack discoveries to validate
+      items:
+        additionalProperties: true
+        type: object
+      type: array
+    connector_name:
+      description: LLM connector name
+      type: string
+    enable_field_rendering:
+      default: true
+      description: Enable field rendering in UI
+      type: boolean
+    generation_uuid:
+      description: Generation execution UUID for tracking
+      type: string
+    replacements:
+      additionalProperties: true
+      description: Anonymization replacements
+      type: object
+    with_replacements:
+      default: false
+      description: Include replacements in response
+      type: boolean
+  required:
+    - alerts_context_count
+    - anonymized_alerts
+    - api_config
+    - attack_discoveries
+    - generation_uuid
+
+steps:
+  # Step 1: Filter hallucinated alert IDs and deduplicate discoveries
+  - name: validate_discoveries
+    type: attack-discovery.defaultValidation
+    with:
+      alerts_context_count: ${{ inputs.alerts_context_count }}
+      alerts_index_pattern: '{%- if inputs.alerts_index_pattern -%}{{ inputs.alerts_index_pattern }}{%- else -%}.alerts-security.alerts-{{ workflow.spaceId }}{%- endif -%}'
+      anonymized_alerts: ${{ inputs.anonymized_alerts }}
+      api_config: ${{ inputs.api_config }}
+      attack_discoveries: ${{ inputs.attack_discoveries }}
+      connector_name: ${{ inputs.connector_name }}
+      generation_uuid: ${{ inputs.generation_uuid }}
+      replacements: ${{ inputs.replacements }}
+
+  # Step 2: Sort validated discoveries by title and persist to Elasticsearch.
+  # The `| sort: "title"` Liquid filter is a trivial transformation that
+  # verifies data flows correctly through the pipeline.
+  - name: persist_discoveries
+    type: attack-discovery.persistDiscoveries
+    with:
+      alerts_context_count: ${{ inputs.alerts_context_count }}
+      anonymized_alerts: ${{ inputs.anonymized_alerts }}
+      api_config: ${{ inputs.api_config }}
+      attack_discoveries: '${{ steps.validate_discoveries.output.validated_discoveries | sort: "title" }}'
+      connector_name: ${{ inputs.connector_name }}
+      enable_field_rendering: ${{ inputs.enable_field_rendering }}
+      generation_uuid: ${{ inputs.generation_uuid }}
+      replacements: ${{ inputs.replacements }}
+      with_replacements: ${{ inputs.with_replacements }}

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/attack_discovery_esql_example.workflow.yaml
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/attack_discovery_esql_example.workflow.yaml
@@ -1,0 +1,159 @@
+version: '1'
+name: Attack discovery - ES|QL example alert retrieval
+description: |
+  Example workflow demonstrating custom alert retrieval using ES|QL.
+  This serves as a reference for users creating their own retrieval workflows.
+
+  The ES|QL query retrieves open and acknowledged security alerts, excluding
+  building block alerts, sorted by risk score (highest first) and timestamp.
+  A KEEP clause limits the output to security-relevant ECS fields that
+  exist in the .alerts-security.alerts-default index.
+
+  This query replicates the behavior of the DSL query in:
+  kbn-elastic-assistant-common/impl/alerts/get_open_and_acknowledged_alerts_query
+
+  NOTE: This is an EXAMPLE workflow. Users should customize the ES|QL query
+  and the KEEP fields for their specific use case.
+enabled: true
+tags:
+  - Attack discovery
+  - Security
+  - Example
+  - attackDiscovery:esql_example_alert_retrieval
+
+triggers:
+  - type: manual
+
+inputs:
+  - name: alerts_index_pattern
+    type: string
+    required: false
+    description: >
+      Elasticsearch index pattern for security alerts. When not provided,
+      defaults to .alerts-security.alerts-<spaceId> using the current
+      Kibana space (via workflow.spaceId).
+  - name: size
+    type: number
+    default: 100
+    description: Maximum alerts to retrieve (1-10000)
+  - name: start
+    type: string
+    required: false
+    default: now-24h
+    description: Time range start (date math, e.g., now-24h, now-7d)
+  - name: end
+    type: string
+    required: false
+    default: now
+    description: Time range end (date math, e.g., now)
+
+steps:
+  # Execute ES|QL query to retrieve open and acknowledged alerts
+  # Sorted by risk score (highest first), then by timestamp (most recent first)
+  # Excludes building block alerts
+  # KEEP fields match the default anonymization fields (DEFAULT_ALLOW)
+  # from elastic_assistant/common/anonymization/index.ts.
+  - name: query_alerts
+    type: elasticsearch.esql.query
+    timeout: '5m'
+    with:
+      # ES|QL query to retrieve open/acknowledged alerts, excluding building blocks
+      query: |
+        {%- if inputs.alerts_index_pattern -%}
+        FROM {{ inputs.alerts_index_pattern }} METADATA _id
+        {%- else -%}
+        FROM .alerts-security.alerts-{{ workflow.spaceId }} METADATA _id
+        {%- endif %}
+        | WHERE kibana.alert.workflow_status IN ("open", "acknowledged")
+        | WHERE kibana.alert.building_block_type IS NULL
+        | SORT kibana.alert.risk_score DESC, @timestamp DESC
+        | LIMIT {{ inputs.size }}
+        | KEEP
+            _id, @timestamp,
+            actions.name, actions.message, actions.status, actions.context,
+            agent.id,
+            asset.criticality,
+            cloud.account.name, cloud.availability_zone, cloud.provider,
+            cloud.region, cloud.service.name,
+            destination.ip,
+            dns.question.name, dns.question.type,
+            entity.id, entity.name, entity.sub_type, entity.type,
+            event.category, event.dataset, event.module, event.outcome,
+            file.Ext.original.path, file.hash.sha256, file.name, file.path,
+            group.id, group.name,
+            host.architecture, host.asset.criticality, host.name,
+            host.os.name, host.os.version,
+            host.risk.calculated_level, host.risk.calculated_score_norm,
+            host.type,
+            kibana.alert.original_time, kibana.alert.risk_score,
+            kibana.alert.rule.description, kibana.alert.rule.name,
+            kibana.alert.rule.references,
+            kibana.alert.rule.threat.framework,
+            kibana.alert.rule.threat.tactic.id,
+            kibana.alert.rule.threat.tactic.name,
+            kibana.alert.rule.threat.tactic.reference,
+            kibana.alert.rule.threat.technique.id,
+            kibana.alert.rule.threat.technique.name,
+            kibana.alert.rule.threat.technique.reference,
+            kibana.alert.rule.threat.technique.subtechnique.id,
+            kibana.alert.rule.threat.technique.subtechnique.name,
+            kibana.alert.rule.threat.technique.subtechnique.reference,
+            kibana.alert.severity, kibana.alert.workflow_status,
+            message,
+            network.protocol,
+            process.args,
+            process.code_signature.exists, process.code_signature.signing_id,
+            process.code_signature.status, process.code_signature.subject_name,
+            process.code_signature.trusted,
+            process.command_line, process.executable, process.exit_code,
+            process.Ext.memory_region.bytes_compressed_present,
+            process.Ext.memory_region.malware_signature.all_names,
+            process.Ext.memory_region.malware_signature.primary.matches,
+            process.Ext.memory_region.malware_signature.primary.signature.name,
+            process.Ext.token.integrity_level_name,
+            process.hash.md5, process.hash.sha1, process.hash.sha256,
+            process.name,
+            process.parent.args, process.parent.args_count,
+            process.parent.code_signature.exists,
+            process.parent.code_signature.status,
+            process.parent.code_signature.subject_name,
+            process.parent.code_signature.trusted,
+            process.parent.command_line, process.parent.executable,
+            process.parent.name,
+            process.pe.original_file_name,
+            process.pid, process.working_directory,
+            Ransomware.feature, Ransomware.files.data,
+            Ransomware.files.entropy, Ransomware.files.extension,
+            Ransomware.files.metrics, Ransomware.files.operation,
+            Ransomware.files.path, Ransomware.files.score,
+            Ransomware.version,
+            resource.id, resource.name, resource.sub_type, resource.type,
+            result.evaluation,
+            rule.description, rule.name, rule.section, rule.tags,
+            rule.benchmark.name, rule.benchmark.id,
+            rule.benchmark.rule_number, rule.benchmark.version,
+            rule.reference,
+            source.ip,
+            threat.framework,
+            threat.tactic.id, threat.tactic.name, threat.tactic.reference,
+            threat.technique.id, threat.technique.name,
+            threat.technique.reference,
+            threat.technique.subtechnique.id,
+            threat.technique.subtechnique.name,
+            threat.technique.subtechnique.reference,
+            user.asset.criticality, user.domain, user.name,
+            user.risk.calculated_level, user.risk.calculated_score_norm,
+            user.target.name,
+            vulnerability.category, vulnerability.classification,
+            vulnerability.description, vulnerability.enumeration,
+            vulnerability.report_id, vulnerability.scanner.vendor,
+            vulnerability.severity, vulnerability.score.base,
+            vulnerability.score.version, vulnerability.id,
+            package.name, package.version, package.fixed_version
+      # Apply time range filter using Elasticsearch DSL (supports date math like now-24h)
+      filter:
+        range:
+          '@timestamp':
+            gte: '${{ inputs.start }}'
+            lte: '${{ inputs.end }}'
+            format: strict_date_optional_time

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/attack_discovery_generation.workflow.yaml
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/attack_discovery_generation.workflow.yaml
@@ -1,0 +1,122 @@
+version: '1'
+name: Attack discovery - Generation
+description: |
+  Generates Attack discoveries from the provided context. This workflow is for
+  Generation only; (no Alert retrieval or validation steps are executed)
+enabled: true
+tags:
+  - Attack discovery
+  - Security
+  - attackDiscovery:generation
+
+triggers:
+  - type: manual
+
+inputs:
+  additionalProperties: false
+  properties:
+    additional_context:
+      description: |
+        Optional free-form text appended to the LLM generation prompt.
+        Use this to provide extra context, constraints, or focus areas
+        that the model should consider when analysing alerts.
+      type: string
+    additional_alerts:
+      default: []
+      description: |
+        Pre-retrieved alerts passed from the pipeline endpoint.
+        The pipeline endpoint runs retrieval workflows separately
+        and passes the results here for generation.
+      items:
+        type: string
+      type: array
+    alert_retrieval_workflow_ids:
+      default: []
+      description: |
+        Array of custom alert retrieval workflow IDs to execute.
+        This array is read but not acted upon by this workflow.
+        The pipeline endpoint handles retrieval orchestration.
+      items:
+        type: string
+      type: array
+    alerts_index_pattern:
+      description: >
+        Elasticsearch index pattern for security alerts. When not provided,
+        defaults to .alerts-security.alerts-<spaceId> using the current
+        Kibana space (via workflow.spaceId).
+      type: string
+    anonymization_fields:
+      description: Fields to anonymize before sending to LLM
+      items:
+        additionalProperties: true
+        type: object
+      type: array
+    api_config:
+      additionalProperties: false
+      description: LLM API configuration
+      properties:
+        action_type_id:
+          type: string
+        connector_id:
+          type: string
+        model:
+          type: string
+      required:
+        - connector_id
+      type: object
+    connector_name:
+      description: Human-readable name of the connector (defaults to connector_id if not provided)
+      type: string
+    end:
+      description: Time range end (e.g., "now")
+      type: string
+    filter:
+      additionalProperties: true
+      description: Elasticsearch query filter
+      type: object
+    default_alert_retrieval_mode:
+      default: 'custom_query'
+      description: |
+        Controls how the built-in default alert retrieval workflow operates.
+        Values: 'custom_query' (DSL-based), 'esql' (ES|QL query), 'disabled'.
+        This field is read but not acted upon by this workflow.
+        The _generate endpoint handles retrieval orchestration.
+      type: string
+      enum: ['disabled', 'esql', 'custom_query']
+    esql_query:
+      description: |
+        ES|QL query for alert retrieval (required when default_alert_retrieval_mode is 'esql').
+      type: string
+    validation_workflow_id:
+      default: 'default'
+      description: |
+        ID of the validation workflow to use, or "default" for built-in validation.
+        This ID is read but not acted upon by this workflow.
+        The _generate endpoint handles validation orchestration.
+      type: string
+    replacements:
+      additionalProperties: true
+      description: Initial anonymization replacements
+      type: object
+    size:
+      default: 150
+      description: Maximum number of alerts to retrieve
+      type: integer
+    start:
+      description: Time range start (e.g., "now-24h")
+      type: string
+  required:
+    - api_config
+
+steps:
+  - name: generate_discoveries
+    type: attack-discovery.generate
+    timeout: '10m'
+    with:
+      additional_context: ${{ inputs.additional_context }}
+      alerts: ${{ inputs.additional_alerts }}
+      api_config: ${{ inputs.api_config }}
+      replacements: ${{ inputs.replacements }}
+      type: attack_discovery
+  # Validation is handled outside this workflow by the _generate endpoint,
+  # which invokes the alert retrieval, generation, and validation workflows sequentially.

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/attack_discovery_run_example.workflow.yaml
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/attack_discovery_run_example.workflow.yaml
@@ -1,0 +1,139 @@
+version: '1'
+name: Attack discovery - Run example
+description: |
+  Demonstrates the attack-discovery.run step, which orchestrates the full
+  Attack Discovery pipeline (alert retrieval → generation → validation) in a
+  single step.
+
+  This example showcases **provided mode** as the primary use case: a
+  detection rule or upstream workflow retrieves alerts and passes them via
+  the `alerts` input, making this workflow fully composable. All other
+  retrieval modes are exposed as optional inputs so the same workflow can
+  also run standalone.
+enabled: true
+tags:
+  - Attack discovery
+  - Security
+  - Example
+  - attackDiscovery:run_example
+
+triggers:
+  - type: manual
+
+inputs:
+  additionalProperties: false
+  properties:
+    additional_context:
+      description: |
+        Optional free-form text appended to the LLM generation prompt.
+        Use this to provide extra context, constraints, or focus areas
+        that the model should consider when analysing alerts.
+        Example: "Focus on lateral movement and privilege escalation."
+      type: string
+    alert_retrieval_mode:
+      default: custom_query
+      description: |
+        Controls how alerts are retrieved before generation.
+        - provided: Skips retrieval; uses the `alerts` input directly.
+          Automatically selected when `alerts` is non-empty.
+        - custom_query: Retrieves alerts via DSL query (default when
+          `alerts` is empty). Respects `start`, `end`, `size`, and `filter`.
+        - esql: Retrieves alerts via the ES|QL query in `esql_query`.
+        - disabled: Skips alert retrieval entirely.
+      enum:
+        - custom_query
+        - disabled
+        - esql
+        - provided
+      type: string
+    alert_retrieval_workflow_ids:
+      default: []
+      description: |
+        Optional array of custom alert retrieval workflow IDs.
+        These workflows run in parallel with the chosen retrieval mode,
+        and their results are merged into the alert set for generation.
+      items:
+        type: string
+      type: array
+    alerts:
+      description: |
+        Pre-retrieved anonymized alert texts. **Primary composability input.**
+        When provided, alert retrieval is skipped automatically
+        (alert_retrieval_mode becomes "provided"). This is how a detection
+        rule, upstream retrieval step, or another workflow feeds alerts
+        into Attack Discovery.
+        Example: steps.my_retrieval_step.output.alerts
+      items:
+        type: string
+      type: array
+    connector_id:
+      description: LLM connector UUID used for generation.
+      type: string
+    end:
+      description: |
+        Time range end (Elasticsearch date math, e.g. "now").
+        Used when alert_retrieval_mode is custom_query.
+      type: string
+    esql_query:
+      description: |
+        ES|QL query for alert retrieval. Required when
+        alert_retrieval_mode is "esql".
+        Example: FROM .alerts-security.alerts-default
+                 | WHERE kibana.alert.severity == "critical"
+                 | LIMIT 50
+      type: string
+    filter:
+      additionalProperties: true
+      description: |
+        Elasticsearch DSL query filter applied during alert retrieval.
+        Used when alert_retrieval_mode is custom_query.
+      type: object
+    mode:
+      default: sync
+      description: |
+        Execution mode for the pipeline.
+        - sync: Waits for the full pipeline and returns discoveries inline.
+        - async: Fires the pipeline and returns execution_uuid immediately.
+      enum:
+        - async
+        - sync
+      type: string
+    size:
+      description: |
+        Maximum number of alerts to retrieve. Applies to custom_query
+        and esql retrieval modes.
+      type: integer
+    start:
+      description: |
+        Time range start (Elasticsearch date math, e.g. "now-24h").
+        Used when alert_retrieval_mode is custom_query.
+      type: string
+    validation_workflow_id:
+      default: ''
+      description: |
+        Override the built-in validation workflow. Pass a workflow ID
+        to use a custom validation workflow, or leave empty to use
+        the default validation.
+      type: string
+  required:
+    - connector_id
+
+steps:
+  - name: run_attack_discovery
+    type: attack-discovery.run
+    timeout: '10m'
+    with:
+      # `alerts` is the primary composability point — when non-empty,
+      # alert_retrieval_mode is automatically set to "provided".
+      additional_context: ${{ inputs.additional_context }}
+      alert_retrieval_mode: ${{ inputs.alert_retrieval_mode }}
+      alert_retrieval_workflow_ids: ${{ inputs.alert_retrieval_workflow_ids }}
+      alerts: ${{ inputs.alerts }}
+      connector_id: ${{ inputs.connector_id }}
+      end: ${{ inputs.end }}
+      esql_query: ${{ inputs.esql_query }}
+      filter: ${{ inputs.filter }}
+      mode: ${{ inputs.mode }}
+      size: ${{ inputs.size }}
+      start: ${{ inputs.start }}
+      validation_workflow_id: ${{ inputs.validation_workflow_id }}

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/attack_discovery_validate.workflow.yaml
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/attack_discovery_validate.workflow.yaml
@@ -1,0 +1,105 @@
+version: '1'
+name: Attack discovery - Default validation
+description: >
+  Validates generated attack discoveries by filtering hallucinated alert IDs,
+  then persists deduplicated discoveries
+enabled: true
+tags:
+  - Attack discovery
+  - Security
+  - attackDiscovery:validate
+
+triggers:
+  - type: manual
+
+inputs:
+  additionalProperties: false
+  properties:
+    alerts_context_count:
+      description: Number of alerts analyzed
+      type: integer
+    alerts_index_pattern:
+      description: >
+        Elasticsearch index pattern for security alerts. When not provided,
+        defaults to .alerts-security.alerts-<spaceId> using the current
+        Kibana space (via workflow.spaceId).
+      type: string
+    anonymized_alerts:
+      description: Anonymized alerts in Document format
+      items:
+        additionalProperties: true
+        type: object
+      type: array
+    api_config:
+      additionalProperties: false
+      description: LLM API configuration
+      properties:
+        action_type_id:
+          type: string
+        connector_id:
+          type: string
+        model:
+          type: string
+      required:
+        - connector_id
+      type: object
+    attack_discoveries:
+      description: Attack discoveries to validate
+      items:
+        additionalProperties: true
+        type: object
+      type: array
+    connector_name:
+      description: LLM connector name
+      type: string
+    enable_field_rendering:
+      default: true
+      description: Enable field rendering in UI
+      type: boolean
+    generation_uuid:
+      description: Generation execution UUID for tracking
+      type: string
+    replacements:
+      additionalProperties: true
+      description: Anonymization replacements
+      type: object
+    with_replacements:
+      default: false
+      description: Include replacements in response
+      type: boolean
+  required:
+    - alerts_context_count
+    - anonymized_alerts
+    - api_config
+    - attack_discoveries
+    - generation_uuid
+
+steps:
+  # Step 1: Filter hallucinated alert IDs and deduplicate discoveries
+  - name: validate_discoveries
+    type: attack-discovery.defaultValidation
+    timeout: '5m'
+    with:
+      alerts_context_count: ${{ inputs.alerts_context_count }}
+      alerts_index_pattern: '{%- if inputs.alerts_index_pattern -%}{{ inputs.alerts_index_pattern }}{%- else -%}.alerts-security.alerts-{{ workflow.spaceId }}{%- endif -%}'
+      anonymized_alerts: ${{ inputs.anonymized_alerts }}
+      api_config: ${{ inputs.api_config }}
+      attack_discoveries: ${{ inputs.attack_discoveries }}
+      connector_name: ${{ inputs.connector_name }}
+      generation_uuid: ${{ inputs.generation_uuid }}
+      replacements: ${{ inputs.replacements }}
+
+  # Step 2: Persist validated discoveries to the Elasticsearch index
+  - name: persist_discoveries
+    type: attack-discovery.persistDiscoveries
+    timeout: '5m'
+    with:
+      alerts_context_count: ${{ inputs.alerts_context_count }}
+      anonymized_alerts: ${{ inputs.anonymized_alerts }}
+      api_config: ${{ inputs.api_config }}
+      attack_discoveries: ${{ steps.validate_discoveries.output.validated_discoveries }}
+      connector_name: ${{ inputs.connector_name }}
+      enable_field_rendering: ${{ inputs.enable_field_rendering }}
+      generation_uuid: ${{ inputs.generation_uuid }}
+      replacements: ${{ inputs.replacements }}
+      with_replacements: ${{ inputs.with_replacements }}

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/default_attack_discovery_alert_retrieval.workflow.yaml
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/default_attack_discovery_alert_retrieval.workflow.yaml
@@ -1,0 +1,83 @@
+version: '1'
+name: Attack discovery - Default alert retrieval
+description: |
+  Retrieves alerts for Attack Discovery analysis via custom queries, or ES|QL.
+  This is the DEFAULT alert retrieval workflow - for custom alert retrieval, create your own workflow.
+enabled: true
+tags:
+  - Attack discovery
+  - Security
+  - attackDiscovery:default_alert_retrieval
+
+triggers:
+  - type: manual
+
+inputs:
+  additionalProperties: false
+  properties:
+    alerts_index_pattern:
+      description: >
+        Elasticsearch index pattern for security alerts. When not provided,
+        defaults to .alerts-security.alerts-<spaceId> using the current
+        Kibana space (via workflow.spaceId).
+      type: string
+    anonymization_fields:
+      description: Fields to anonymize
+      items:
+        additionalProperties: true
+        type: object
+      type: array
+    api_config:
+      additionalProperties: false
+      description: LLM API configuration
+      properties:
+        action_type_id:
+          type: string
+        connector_id:
+          type: string
+        model:
+          type: string
+      required:
+        - connector_id
+      type: object
+    end:
+      description: Time range end
+      type: string
+    esql_query:
+      description: >
+        Optional ES|QL query for alert retrieval. When provided, overrides the
+        default DSL-based retrieval and executes this ES|QL query instead.
+      type: string
+    filter:
+      additionalProperties: true
+      description: Query filter for alerts
+      type: object
+    replacements:
+      additionalProperties: true
+      description: Existing anonymization replacements to use
+      type: object
+    size:
+      default: 150
+      description: Maximum alerts to retrieve
+      type: integer
+    start:
+      description: Time range start
+      type: string
+  required:
+    - anonymization_fields
+    - api_config
+
+steps:
+  - name: retrieve_alerts
+    type: attack-discovery.defaultAlertRetrieval
+    timeout: '5m'
+    with:
+      alerts_index_pattern: '{%- if inputs.alerts_index_pattern -%}{{ inputs.alerts_index_pattern }}{%- else -%}.alerts-security.alerts-{{ workflow.spaceId }}{%- endif -%}'
+      anonymization_fields: ${{ inputs.anonymization_fields }}
+      api_config: ${{ inputs.api_config }}
+      end: ${{ inputs.end }}
+      esql_query: ${{ inputs.esql_query }}
+      filter: ${{ inputs.filter }}
+      replacements: ${{ inputs.replacements }}
+      size: ${{ inputs.size }}
+      start: ${{ inputs.start }}

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/readme.md
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/readme.md
@@ -1,0 +1,448 @@
+# Attack Discovery Workflow Definitions
+
+This document describes the out-of-the-box Attack Discovery workflows and their purposes.
+
+## Overview
+
+The Attack Discovery workflow architecture decouples alert retrieval, generation, and validation into modular, reusable components. The pipeline endpoint (`POST /internal/attack_discovery/_generate`) kicks off the generation workflow asynchronously, returns an execution UUID, and persists discoveries via the validation step.
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph API["POST /internal/attack_discovery/_generate (pipeline)"]
+        direction TB
+        A["Request with connectorId, filters, size, etc.<br/>(only connector_id required in api_config)"]
+    end
+
+    subgraph Orchestrator["Pipeline Orchestrator (3 sequential workflow executions)"]
+        direction TB
+        B["1. Alert Retrieval Workflow"]
+        C["2. Generation Workflow"]
+        D["3. Validation Workflow<br/>(validate + persist)"]
+        B --> C --> D
+    end
+
+    subgraph Steps["Workflow Step Types"]
+        direction TB
+        E["attack-discovery.defaultAlertRetrieval"]
+        F["attack-discovery.generate"]
+        G["attack-discovery.defaultValidation"]
+        G2["attack-discovery.persistDiscoveries"]
+        G3["attack-discovery.run (full pipeline)"]
+    end
+
+    subgraph Storage["Elasticsearch"]
+        direction TB
+        H[".alerts-security.alerts-*"]
+        I[Attack Discovery Index]
+    end
+
+    A --> Orchestrator
+    B -.-> E
+    C -.-> F
+    D -.-> G
+    D -.-> G2
+    E --> H
+    G2 --> I
+```
+
+### Data Flow
+
+1. **Request**: The pipeline endpoint receives parameters (connector config with only `connector_id` required, filters, time range, etc.) and returns an execution UUID immediately
+2. **Alert Retrieval**: Queries Elasticsearch for alerts matching the criteria and anonymizes sensitive fields
+3. **Generation**: Sends anonymized alerts to the LLM for attack pattern analysis
+4. **Validation**: Stores generated discoveries in the Attack Discovery index for the Security UI
+
+> **Self-Healing**: The 3 required default workflows (`default-attack-discovery-alert-retrieval`, `attack-discovery-generation`, `attack-discovery-validate`) are protected by an integrity verification system that detects and automatically repairs deletions or modifications before each generation run. See the [Self-Healing section](../../../README.md#self-healing--workflow-integrity-verification) in the plugin README.
+
+## Workflow Definitions
+
+### 1. Default Alert Retrieval (`default-attack-discovery-alert-retrieval`)
+
+**File**: `default_attack_discovery_alert_retrieval.workflow.yaml`
+
+**Purpose**: Retrieves and anonymizes alerts from Elasticsearch using built-in logic. This is the LEGACY alert retrieval mechanism used by the `_generate` endpoint. For custom alert retrieval, create your own workflow.
+
+**When to Use**:
+- Default alert retrieval for production use cases
+- When you need standard anonymization of sensitive fields
+- As the data source for generation workflows
+
+#### Inputs
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `alertsIndexPattern` | string | ✅ | - | Alert index pattern to search (e.g., `.alerts-security.alerts-default`) |
+| `anonymizationFields` | array | ✅ | - | Fields to anonymize (see anonymization config below) |
+| `apiConfig` | string | ✅ | - | LLM API configuration (JSON string). Only `connector_id` is required; `action_type_id` is resolved at runtime when omitted |
+| `filter` | string | ❌ | - | Query filter for alerts (JSON string) |
+| `size` | number | ❌ | `150` | Maximum alerts to retrieve |
+| `start` | string | ❌ | - | Time range start (e.g., `now-24h`) |
+| `end` | string | ❌ | - | Time range end (e.g., `now`) |
+
+#### Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| `alerts` | string[] | Retrieved alerts as anonymized strings (for LLM consumption) |
+| `anonymized_alerts` | Document[] | Anonymized alert documents (for validation) |
+| `replacements` | Record<string, string> | Anonymization replacements map |
+| `api_config` | ApiConfig | LLM API configuration (passed through) |
+| `connector_name` | string | LLM connector name (resolved from connector_id when not provided in input) |
+| `alerts_context_count` | number | Number of alerts retrieved |
+
+---
+
+### 2. ES|QL Example (`attack-discovery-esql-example`)
+
+**File**: `attack_discovery_esql_example.workflow.yaml`
+
+**Purpose**: Demonstrates custom alert retrieval using ES|QL queries via the `elasticsearch.esql.query` step type. This workflow serves as a reference implementation for teams who want to customize how alerts are retrieved.
+
+The ES|QL query replicates the behavior of the DSL query in `kbn-elastic-assistant-common/impl/alerts/get_open_and_acknowledged_alerts_query`:
+- Retrieves alerts with `workflow_status` IN ('open', 'acknowledged')
+- Excludes building block alerts (`building_block_type` IS NULL)
+- Sorts by `risk_score` (descending), then `@timestamp` (descending)
+- Applies configurable time range filter using Elasticsearch DSL date math
+
+**When to Use**:
+- Reference implementation for building custom retrieval workflows
+- When you need custom ES|QL-based alert queries
+- For advanced filtering and transformation scenarios
+
+#### Inputs
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `alerts_index_pattern` | string | ✅ | - | Alert index pattern (e.g., `.alerts-security.alerts-default`) |
+| `size` | number | ❌ | `100` | Maximum alerts to retrieve (1-10000) |
+| `start` | string | ❌ | `now-24h` | Time range start (date math) |
+| `end` | string | ❌ | `now` | Time range end (date math) |
+
+#### Outputs
+
+The `elasticsearch.esql.query` step returns ES|QL query results in the standard format:
+- `columns`: Array of column metadata (name, type)
+- `values`: Array of row arrays containing the query results
+
+**Note**: Unlike the legacy retrieval workflow, this ES|QL example returns raw query results without anonymization. Users should add post-processing steps if anonymization is required.
+
+---
+
+### 3. Generation (`attack-discovery-generation`)
+
+**File**: `attack_discovery_generation.workflow.yaml`
+
+**Purpose**: Generates Attack discoveries from the provided context. This workflow is for Generation only; no Alert retrieval or validation steps are executed. The `_generate` endpoint orchestrates alert retrieval, generation, and validation as separate workflow executions.
+
+**When to Use**:
+- Invoked by the `_generate` endpoint's manual orchestrator (not typically called directly)
+- When you need only the generation step with pre-retrieved alerts
+
+#### Inputs
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `additional_alerts` | string[] | ❌ | `[]` | Pre-retrieved alerts passed from the pipeline endpoint |
+| `api_config` | object | ✅ | - | LLM connector configuration. Only `connector_id` is required; `action_type_id` is resolved at runtime when omitted |
+| `replacements` | object | ❌ | - | Initial anonymization replacements |
+
+#### Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| `alerts_context_count` | number | Number of alerts analyzed |
+| `attack_discoveries` | array | Generated attack discoveries |
+| `execution_uuid` | string | Generation execution UUID for tracking |
+| `replacements` | string | Updated anonymization replacements |
+
+---
+
+### 4. Default Validation (`attack-discovery-validate`)
+
+**File**: `attack_discovery_validate.workflow.yaml`
+
+**Purpose**: Validates generated discoveries and persists them to the Attack Discovery Elasticsearch index. This makes the discoveries visible in the Security UI.
+
+**When to Use**:
+- Default validation for storing discoveries
+- As the final step in the generation pipeline
+- When you want discoveries visible in the Attack Discovery UI
+
+#### Inputs
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `attackDiscoveries` | array | ✅ | - | Attack discoveries to validate |
+| `anonymizedAlerts` | array | ✅ | - | Anonymized alerts in Document format |
+| `apiConfig` | string | ✅ | - | LLM API configuration (JSON string). Only `connector_id` is required; `action_type_id` is resolved at runtime when omitted |
+| `connectorName` | string | ❌ | - | LLM connector name (resolved from connector_id when omitted) |
+| `generationUuid` | string | ✅ | - | Generation execution UUID for tracking |
+| `alertsContextCount` | number | ✅ | - | Number of alerts analyzed |
+| `replacements` | string | ❌ | - | Anonymization replacements (JSON string) |
+| `enableFieldRendering` | boolean | ❌ | `true` | Enable field rendering in UI |
+| `withReplacements` | boolean | ❌ | `false` | Include replacements in response |
+
+#### Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| `validated_discoveries` | AttackDiscoveryApiAlert[] | Validated discoveries as alerts |
+
+---
+
+## Data Contracts
+
+### TypeScript Types
+
+The workflow inputs and outputs are defined in the `@kbn/discoveries` package:
+
+```typescript
+// API Configuration
+interface ApiConfig {
+  action_type_id?: string; // Optional — resolved from connector_id at runtime
+  connector_id: string;    // Connector UUID (only required field)
+  model?: string;          // Optional model name
+}
+
+// Anonymization Field Configuration
+interface AnonymizationField {
+  id: string;              // Unique field identifier
+  field: string;           // Field path (e.g., 'host.name')
+  allowed: boolean;        // Whether field is allowed in output
+  anonymized: boolean;     // Whether to anonymize this field
+}
+
+// Attack Discovery Output
+interface AttackDiscovery {
+  id: string;
+  title: string;
+  alertIds: string[];
+  timestamp: string;
+  detailsMarkdown: string;
+  summaryMarkdown: string;
+  entitySummaryMarkdown?: string;
+  mitreAttackTactics?: string[];
+}
+
+// Replacements Map
+type Replacements = Record<string, string>;
+// Example: { "SRVHQMWPN001": "dc01.example.com" }
+```
+
+### Workflow Step Data Flow
+
+```
+┌──────────────────────┐
+│   Alert Retrieval    │
+│                      │
+│  Input:              │
+│  - alertsIndexPattern│
+│  - anonymizationFields│
+│  - apiConfig (only   │
+│    connector_id req) │
+│  - filter, size, etc.│
+│                      │
+│  Output:             │
+│  - alerts (string[]) │
+│  - anonymized_alerts │
+│  - replacements      │
+│  - api_config        │
+│  - connector_name    │
+│  - alerts_context_count│
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│     Generation       │
+│                      │
+│  Input:              │
+│  - alerts            │◄── from retrieve_alerts.output.alerts
+│  - api_config        │◄── from retrieve_alerts.output.api_config
+│  - replacements      │◄── from retrieve_alerts.output.replacements
+│  - type, size        │
+│                      │
+│  Output:             │
+│  - attack_discoveries│
+│  - execution_uuid    │
+│  - replacements      │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│     Validation       │
+│                      │
+│  Input:              │
+│  - attack_discoveries│◄── from generate.output.attack_discoveries
+│  - anonymized_alerts │◄── from retrieve_alerts.output.anonymized_alerts
+│  - api_config        │◄── from retrieve_alerts.output.api_config
+│  - connector_name    │◄── from retrieve_alerts.output.connector_name (optional)
+│  - generation_uuid   │◄── from generate.output.execution_uuid
+│  - alerts_context_count│◄── from retrieve_alerts.output.alerts_context_count
+│  - replacements      │◄── from generate.output.replacements
+│                      │
+│  Output:             │
+│  - validated_discoveries│
+└──────────────────────┘
+```
+
+---
+
+## Workflow IDs
+
+The following well-known workflow IDs are defined in `@kbn/discoveries/impl/attack_discovery/constants`:
+
+| Constant | Workflow ID | Description |
+|----------|-------------|-------------|
+| `ATTACK_DISCOVERY_DEFAULT_VALIDATION_WORKFLOW_ID` | `attack-discovery-validate` | Default validation workflow |
+| `ATTACK_DISCOVERY_ESQL_EXAMPLE_WORKFLOW_ID` | `attack-discovery-esql-example` | ES|QL example workflow |
+| `ATTACK_DISCOVERY_DEFAULT_ALERT_RETRIEVAL_WORKFLOW_ID` | `default-attack-discovery-alert-retrieval` | Default alert retrieval |
+| `ATTACK_DISCOVERY_CUSTOM_VALIDATION_EXAMPLE_WORKFLOW_ID` | `attack-discovery-custom-validation-example` | Custom validation example (validate → sort → persist) |
+| `ATTACK_DISCOVERY_GENERATION_WORKFLOW_ID` | `attack-discovery-generation` | Generation workflow |
+| `ATTACK_DISCOVERY_RUN_EXAMPLE_WORKFLOW_ID` | `attack-discovery-run-example` | Run example (full pipeline via `attack-discovery.run` step) |
+
+---
+
+## Liquid Filter Patterns
+
+User-authored workflows use [Liquid](https://shopify.github.io/liquid/) expressions to thread data between steps. Several patterns are especially relevant for Attack Discovery workflows.
+
+### The `| json` Filter (Alert Format Conversion)
+
+The `attack-discovery.generate` step accepts alerts as `string[]` — each element is an anonymized text representation of an alert. When composing workflows that retrieve alerts from a different source (e.g., an ES|QL query step), the raw output may be structured data (objects, arrays of arrays, etc.). The `| json` Liquid filter converts structured data to a JSON string, enabling format conversion between steps with incompatible types.
+
+**Example**: Converting ES|QL query output to a JSON string for downstream processing:
+
+```yaml
+steps:
+  - name: query_alerts
+    type: elasticsearch.esql.query
+    with:
+      query: "FROM .alerts-security.alerts-default | LIMIT 10"
+
+  - name: format_alerts
+    type: transform
+    with:
+      data: '${{ steps.query_alerts.output.values | json }}'
+```
+
+The `| json` filter serializes the value to a JSON string. This is the inverse of the `| parse_json` filter (where available). Use it when a downstream step expects a string representation of structured data.
+
+### The `| sort` Filter (Reordering Step Outputs)
+
+The sorted validation example workflow demonstrates using `| sort: "title"` to reorder discoveries alphabetically between the validation and persist steps:
+
+```yaml
+attack_discoveries: '${{ steps.validate_discoveries.output.validated_discoveries | sort: "title" }}'
+```
+
+This pattern allows trivial data transformations between steps without requiring a custom step type. See `attack_discovery_custom_validation_example.workflow.yaml` for the complete example.
+
+### The `| size` Filter (Counting Elements)
+
+The generation workflow uses `| size` to count the number of alerts passed as input:
+
+```yaml
+outputs:
+  - name: alerts_context_count
+    value: ${{ inputs.additional_alerts | size }}
+```
+
+---
+
+## Debugging with Execution Tracing
+
+Every generation run is assigned a unique `executionUuid`. The traced logger prefixes **all** log messages for that run with `[execution: {uuid}]`, allowing you to filter logs for a single execution across all three pipeline steps.
+
+### Execution Trace ID Pattern
+
+All server log messages from a generation run share the same trace prefix:
+
+```
+[plugins.discoveries] [execution: abc-123-def] Health check [retrieval]: ...
+[plugins.discoveries] [execution: abc-123-def] Health check [generation]: ...
+[plugins.discoveries] [execution: abc-123-def] Orchestration summary [succeeded] in 12345ms | ...
+```
+
+Filter for a specific execution:
+
+```bash
+grep "execution: abc-123-def" kibana.log
+```
+
+The same `executionUuid` links log messages to event log entries (`kibana.alert.rule.execution.uuid`) and the API response from `POST /internal/attack_discovery/_generate`.
+
+### INFO-Level Execution Summary (Default Logging)
+
+After every orchestration run, a single INFO-level summary is logged automatically (no config changes needed):
+
+```
+[execution: abc-123-def] Orchestration summary [succeeded] in 12345ms | alerts: 50, discoveries: 3
+  retrieval: succeeded (4500ms) [default-attack-discovery-alert-retrieval] /app/workflows/default-attack-discovery-alert-retrieval?tab=executions&executionId=ret-run-id
+  generation: succeeded (6000ms) [attack-discovery-generation] /app/workflows/attack-discovery-generation?tab=executions&executionId=gen-run-id
+  validation: succeeded (1800ms) [attack-discovery-validate] /app/workflows/attack-discovery-validate?tab=executions&executionId=val-run-id
+```
+
+On failure, the summary shows which step failed:
+
+```
+[execution: abc-123-def] Orchestration summary [failed] in 6500ms | alerts: 50, discoveries: 0
+  retrieval: succeeded (4500ms) [default-attack-discovery-alert-retrieval] /app/workflows/...
+  generation: failed (2000ms) error="Request timed out after 10m"
+  validation: not started
+```
+
+### DEBUG-Level Health Checks
+
+Before each orchestration step, a DEBUG-level health check logs the preconditions. These use lazy evaluation (`logger.debug(() => ...)`) so they have zero cost when debug logging is off.
+
+**Enable debug logging** in `kibana.dev.yml`:
+
+```yaml
+logging:
+  loggers:
+    - name: plugins.discoveries
+      level: debug
+```
+
+**Health check format**:
+
+```
+[execution: {uuid}] Health check [{step}]: key1=value1, key2=value2
+```
+
+**Preconditions verified per step**:
+
+| Step | Preconditions | What to look for |
+|------|---------------|------------------|
+| **retrieval** | `alertsIndexPattern`, `anonymizationFieldCount`, `connectorId`, `customWorkflowIds`, `defaultAlertRetrievalWorkflowId`, `retrievalMode` | `anonymizationFieldCount=0` means no anonymization fields configured; `retrievalMode` should match your intent |
+| **generation** | `alertCount`, `connectorId`, `generationWorkflowId` | `alertCount=0` means no alerts were retrieved — check time range and filters |
+| **validation** | `defaultValidationWorkflowId`, `discoveryCount`, `persist`, `validationWorkflowId` | `discoveryCount=0` means the LLM found no attack patterns in the alerts |
+
+**Example** (retrieval step):
+
+```
+[execution: abc-123-def] Health check [retrieval]: alertsIndexPattern=".alerts-security.alerts-default", anonymizationFieldCount=140, connectorId="my-connector-id", customWorkflowIds=[], defaultAlertRetrievalWorkflowId="default-attack-discovery-alert-retrieval", retrievalMode="custom_query"
+```
+
+### Troubleshooting Common Issues
+
+| Symptom | Where to look | Resolution |
+|---------|---------------|------------|
+| "0 new attacks discovered" | Execution summary — check if retrieval step returned `alerts: 0` | Verify alert time range, index pattern, and filters |
+| Pipeline never starts | Pre-execution validation warnings (WARN level) | Check connector accessibility and alerts index existence |
+| Startup warnings | Startup health check (INFO/WARN level) | Ensure workflow steps registered and WorkflowsManagement API is available |
+| Specific step failure | Execution summary — step line shows `failed` with error message | Follow the workflow link to see detailed inputs/outputs |
+| Fleet-wide patterns | EBT telemetry events | See [Telemetry README](../../lib/telemetry/README.md) for `attack_discovery_misconfiguration` and `attack_discovery_step_failure` |
+
+### Execution Flow Path
+
+The `_generate` endpoint executes via the **Generation Workflow Path**, which requires the `workflowsManagementApi` to be available. The orchestrator (`run_manual_orchestration`) sequences the three sub-workflows (alert retrieval, generation, validation) using real Kibana Workflow executions. Each step runs as a separate workflow execution, and all are linked by the shared `executionUuid` in log messages.
+
+---
+
+## See Also
+
+- [README.md](../../../README.md) - Plugin overview and API documentation
+- [GENERATE_REQUEST_PROPERTY_TRACING.md](../../../docs/GENERATE_REQUEST_PROPERTY_TRACING.md) - Request property flow documentation

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/test/attack_discovery_agent_builder_alert_retrieval.workflow.yaml
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/test/attack_discovery_agent_builder_alert_retrieval.workflow.yaml
@@ -1,0 +1,125 @@
+version: '1'
+name: Attack discovery - Agent builder alert retrieval (Test)
+description: |
+  Test workflow that uses the native `ai.agent` step type to invoke the
+  Agent Builder and retrieve security alerts for Attack Discovery analysis.
+  The AI agent determines the best approach to find and return the alerts,
+  so the response format is not known in advance.
+
+  This demonstrates using the `ai.agent` step type (the idiomatic way to
+  call Agent Builder from workflows) as an alternative alert retrieval
+  mechanism for Attack Discovery workflows. No `agent_id` input is needed
+  because `ai.agent` defaults to the built-in `elastic-ai-agent`.
+
+  PROMPT NOTES:
+  - The `platform.core.search` tool used by the default Elastic AI agent
+    accepts natural language queries, NOT Elasticsearch DSL.
+  - Prompts that include DSL-like instructions (field lists, query JSON,
+    `_source: false`) cause the agent to DESCRIBE the query instead of
+    EXECUTING it.
+  - The phrase "Show me the N most recent ... from <index>" reliably
+    triggers tool use. Adding filter/sort constraints (e.g., "riskiest",
+    "open or acknowledged") makes tool invocation UNRELIABLE.
+  - Asking for "all available fields" or "raw results" causes the agent
+    to return truncated placeholders or hit content management filters.
+  - Requesting a specific short list of fields (timestamp, rule name,
+    risk score, severity, host, user, process) produces the most useful
+    output: a clean markdown table with real data and no abbreviations.
+  - The prompt asks the agent to exclude building block alerts (alerts
+    where `kibana.alert.building_block_type` is set). This is consistent
+    with all other attack discovery alert retrieval workflows, which
+    exclude building blocks to avoid noise from low-level signal alerts.
+
+  TOKEN LIMIT NOTE: Each search-tool invocation returns full alert documents
+  into the conversation context. Even 10 alerts consume ~140K input tokens
+  across multiple LLM calls. Requesting 100 alerts with all fields (~184K
+  tokens) exceeds the model's context window. The default size is 10.
+
+  SINGLE STEP NOTE: This workflow uses a single step to avoid data loss
+  from multi-step workflows. `extractCustomWorkflowResult` takes the LAST
+  step's output; a followup step that loses conversation context would
+  overwrite the real alert data. A single step is the most reliable
+  approach since specific step outputs cannot be referenced.
+
+  NORMALIZATION NOTE: The `ai.agent` step returns
+  `{ message, structured_output?, conversation_id? }`. Since
+  `normalizeLastStepOutput` does not recognize this shape as ES|QL
+  (`{ columns, values }`) or as an array, it falls through to the
+  "plain object" fallback and JSON.stringifies the entire response as
+  ONE alert string. The actual alerts are in the `message` text as a
+  markdown table, not as structured data. This tests the "unknown output
+  format" edge case in the extraction pipeline.
+
+  NOTE: This is a TEST workflow. It is NOT registered at startup.
+enabled: true
+tags:
+  - Attack discovery
+  - Security
+  - Test
+  - AI Agent
+  - attackDiscovery:agent_builder_alert_retrieval
+
+triggers:
+  - type: manual
+
+inputs:
+  - name: alerts_index_pattern
+    type: string
+    required: false
+    description: >
+      Elasticsearch index pattern for security alerts. When not provided,
+      defaults to .alerts-security.alerts-<spaceId> using the current
+      Kibana space (via workflow.spaceId).
+  - name: size
+    type: number
+    default: 10
+    description: >
+      Maximum alerts to retrieve. Kept low (default 10) because each alert
+      returned by the search tool consumes significant tokens in the agent
+      conversation context (~14K tokens per alert). Values above ~20 risk
+      exceeding the model context window.
+  - name: start
+    type: string
+    required: false
+    default: now-24h
+    description: Time range start (date math, e.g., now-24h, now-7d)
+  - name: end
+    type: string
+    required: false
+    default: now
+    description: Time range end (date math, e.g., now)
+
+steps:
+  # Ask the Agent Builder to retrieve the most recent alerts.
+  #
+  # Uses the native `ai.agent` step type which automatically invokes
+  # the default Elastic AI agent (elastic-ai-agent) without requiring
+  # an explicit agent_id. The agent has the `platform.core.search` tool
+  # which allows it to search Elasticsearch indices directly.
+  #
+  # CRITICAL: The prompt must be simple natural language. The
+  # `platform.core.search` tool is a natural language search tool --
+  # DSL-like instructions cause the agent to describe the query rather
+  # than execute it.
+  #
+  # RELIABILITY: Through iterative API testing, the phrasing
+  # "Show me the N most recent ... from <index>" was validated as the
+  # most reliable trigger for tool use (3/3 success rate). Adding
+  # filter/sort constraints like "riskiest" or "open or acknowledged"
+  # reduced tool invocation to <50%. Requesting specific fields
+  # (timestamp, rule name, risk score, etc.) produces clean tabular
+  # output without abbreviations like "Same as above".
+  - name: ask_agent_for_alerts
+    type: ai.agent
+    timeout: 10m
+    with:
+      message: >
+        Show me the {{ inputs.size }} most recent security alerts from the
+        {%- if inputs.alerts_index_pattern %} {{ inputs.alerts_index_pattern }}
+        {%- else %} .alerts-security.alerts-{{ workflow.spaceId }}
+        {%- endif %} index that are not building block
+        alerts. Include the timestamp, rule name, risk score, severity, host,
+        user, and process for each.
+    on-failure:
+      retry:
+        max-attempts: 3

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/test/attack_discovery_closed_alerts_esql_retrieval.workflow.yaml
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/test/attack_discovery_closed_alerts_esql_retrieval.workflow.yaml
@@ -1,0 +1,178 @@
+version: '1'
+name: Attack discovery - Closed alerts ES|QL retrieval (Test)
+description: |
+  Test workflow that retrieves closed security alerts using ES|QL.
+
+  Unlike the main ES|QL example workflow (which retrieves open and acknowledged
+  alerts), this workflow filters for alerts with workflow_status == "closed".
+  It excludes building block alerts and sorts by risk score (highest first)
+  then timestamp (most recent first).
+
+  The KEEP clause returns security-relevant ECS fields from the
+  .alerts-security.alerts-default index.
+
+  NOTE: This is a TEST workflow. It is NOT registered at startup.
+enabled: true
+tags:
+  - Attack discovery
+  - Security
+  - Test
+  - attackDiscovery:closed_alerts_esql_retrieval
+
+triggers:
+  - type: manual
+
+inputs:
+  - name: alerts_index_pattern
+    type: string
+    required: false
+    description: >
+      Elasticsearch index pattern for security alerts. When not provided,
+      defaults to .alerts-security.alerts-<spaceId> using the current
+      Kibana space (via workflow.spaceId).
+  - name: size
+    type: number
+    default: 100
+    description: Maximum alerts to retrieve (1-10000)
+  - name: start
+    type: string
+    required: false
+    default: now-24h
+    description: Time range start (date math, e.g., now-24h, now-7d)
+  - name: end
+    type: string
+    required: false
+    default: now
+    description: Time range end (date math, e.g., now)
+
+steps:
+  - name: query_closed_alerts
+    type: elasticsearch.esql.query
+    timeout: '5m'
+    with:
+      query: |
+        {%- if inputs.alerts_index_pattern -%}
+        FROM {{ inputs.alerts_index_pattern }} METADATA _id
+        {%- else -%}
+        FROM .alerts-security.alerts-{{ workflow.spaceId }} METADATA _id
+        {%- endif %}
+        | WHERE @timestamp >= NOW() - 24 hours
+        | WHERE kibana.alert.workflow_status == "closed"
+        | WHERE kibana.alert.building_block_type IS NULL
+        | SORT kibana.alert.risk_score DESC, @timestamp DESC
+        | LIMIT {{ inputs.size }}
+        | KEEP
+            _id,
+            @timestamp,
+            agent.id,
+            cloud.account.name,
+            cloud.availability_zone,
+            cloud.provider,
+            cloud.region,
+            cloud.service.name,
+            destination.ip,
+            dns.question.name,
+            dns.question.type,
+            entity.id,
+            entity.name,
+            entity.sub_type,
+            entity.type,
+            event.category,
+            event.dataset,
+            event.module,
+            event.outcome,
+            file.hash.sha256,
+            file.name,
+            file.path,
+            group.id,
+            group.name,
+            host.architecture,
+            host.asset.criticality,
+            host.name,
+            host.os.name,
+            host.os.version,
+            host.risk.calculated_level,
+            host.risk.calculated_score_norm,
+            host.type,
+            kibana.alert.original_time,
+            kibana.alert.risk_score,
+            kibana.alert.rule.description,
+            kibana.alert.rule.name,
+            kibana.alert.rule.references,
+            kibana.alert.rule.threat.framework,
+            kibana.alert.rule.threat.tactic.id,
+            kibana.alert.rule.threat.tactic.name,
+            kibana.alert.rule.threat.tactic.reference,
+            kibana.alert.rule.threat.technique.id,
+            kibana.alert.rule.threat.technique.name,
+            kibana.alert.rule.threat.technique.reference,
+            kibana.alert.rule.threat.technique.subtechnique.id,
+            kibana.alert.rule.threat.technique.subtechnique.name,
+            kibana.alert.rule.threat.technique.subtechnique.reference,
+            kibana.alert.severity,
+            kibana.alert.workflow_status,
+            message,
+            network.protocol,
+            package.name,
+            package.version,
+            process.args,
+            process.code_signature.exists,
+            process.code_signature.signing_id,
+            process.code_signature.status,
+            process.code_signature.subject_name,
+            process.code_signature.trusted,
+            process.command_line,
+            process.executable,
+            process.exit_code,
+            process.hash.md5,
+            process.hash.sha1,
+            process.hash.sha256,
+            process.name,
+            process.parent.args,
+            process.parent.args_count,
+            process.parent.code_signature.exists,
+            process.parent.code_signature.status,
+            process.parent.code_signature.subject_name,
+            process.parent.code_signature.trusted,
+            process.parent.command_line,
+            process.parent.executable,
+            process.parent.name,
+            process.pe.original_file_name,
+            process.pid,
+            process.working_directory,
+            rule.description,
+            rule.name,
+            rule.reference,
+            source.ip,
+            threat.framework,
+            threat.tactic.id,
+            threat.tactic.name,
+            threat.tactic.reference,
+            threat.technique.id,
+            threat.technique.name,
+            threat.technique.reference,
+            threat.technique.subtechnique.id,
+            threat.technique.subtechnique.name,
+            threat.technique.subtechnique.reference,
+            user.asset.criticality,
+            user.domain,
+            user.name,
+            user.risk.calculated_level,
+            user.risk.calculated_score_norm,
+            user.target.name,
+            vulnerability.category,
+            vulnerability.classification,
+            vulnerability.description,
+            vulnerability.enumeration,
+            vulnerability.id,
+            vulnerability.report_id,
+            vulnerability.scanner.vendor,
+            vulnerability.score.base,
+            vulnerability.score.version,
+            vulnerability.severity
+      filter:
+        range:
+          '@timestamp':
+            gte: '${{ inputs.start }}'
+            lte: '${{ inputs.end }}'
+            format: strict_date_optional_time

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/test/attack_discovery_query_dsl_alert_retrieval.workflow.yaml
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/test/attack_discovery_query_dsl_alert_retrieval.workflow.yaml
@@ -1,0 +1,169 @@
+version: '1'
+name: Attack discovery - Query DSL alert retrieval (Test)
+description: |
+  Test workflow that replicates the behavior of the ES|QL Example Alert
+  Retrieval workflow, but uses an `elasticsearch.search` step with
+  Elasticsearch Query DSL instead of the `elasticsearch.esql.query` step.
+
+  The DSL query is the workflow equivalent of the TypeScript function
+  `getOpenAndAcknowledgedAlertsQuery` from:
+  kbn-elastic-assistant-common/impl/alerts/get_open_and_acknowledged_alerts_query
+
+  It retrieves open and acknowledged security alerts, excludes building
+  block alerts, and returns security-relevant fields. The `fields` list
+  mirrors the KEEP clause from the ES|QL example workflow.
+
+  SORT NOTE: The original TypeScript query sorts by risk_score DESC
+  then @timestamp DESC, but the workflow JSON schema for
+  `elasticsearch.search` flattens body and URL query params, causing
+  the URL-param `sort` type (string-only) to override the body `sort`
+  type (which supports objects with order). Sort is therefore omitted
+  to avoid schema validation errors that prevent enabling the workflow.
+
+  NORMALIZATION NOTE: The `elasticsearch.search` step returns the full
+  Elasticsearch search response (`{ hits: { hits: [...] }, ... }`), which
+  is NOT the ES|QL `{ columns, values }` shape. `normalizeLastStepOutput`
+  will JSON.stringify the entire response as one single alert string (the
+  "plain object" fallback), collapsing all hits into one blob. This is
+  realistic: a real user writing a Query DSL workflow would not add a
+  reformatting step -- they would just run the query and expect it to work.
+  This tests how the extraction pipeline handles the Elasticsearch search
+  response shape.
+
+  NOTE: This is a TEST workflow. It is NOT registered at startup.
+enabled: true
+tags:
+  - Attack discovery
+  - Security
+  - Test
+  - attackDiscovery:query_dsl_alert_retrieval
+
+triggers:
+  - type: manual
+
+inputs:
+  - name: alerts_index_pattern
+    type: string
+    required: false
+    description: >
+      Elasticsearch index pattern for security alerts. When not provided,
+      defaults to .alerts-security.alerts-<spaceId> using the current
+      Kibana space (via workflow.spaceId).
+  - name: size
+    type: number
+    default: 100
+    description: Maximum alerts to retrieve (1-10000)
+  - name: start
+    type: string
+    required: false
+    default: now-24h
+    description: Time range start (date math, e.g., now-24h, now-7d)
+  - name: end
+    type: string
+    required: false
+    default: now
+    description: Time range end (date math, e.g., now)
+
+steps:
+  # Execute an Elasticsearch Query DSL search that is equivalent to the
+  # ES|QL query in attack_discovery_esql_example.workflow.yaml and to the
+  # TypeScript function getOpenAndAcknowledgedAlertsQuery from
+  # kbn-elastic-assistant-common.
+  #
+  # The query:
+  # - Filters for open/acknowledged alerts (workflow_status)
+  # - Excludes building block alerts (must_not exists building_block_type)
+  # - Applies a time range filter on @timestamp
+  # - Returns only the security-relevant fields (matching the ESQL KEEP clause)
+  # - Uses _source: false with explicit fields for efficiency
+  # - Sort is omitted (see SORT NOTE in description)
+  - name: search_alerts
+    type: elasticsearch.search
+    timeout: '5m'
+    with:
+      index: '{%- if inputs.alerts_index_pattern -%}{{ inputs.alerts_index_pattern }}{%- else -%}.alerts-security.alerts-{{ workflow.spaceId }}{%- endif -%}'
+      size: "{{ inputs.size }}"
+      _source: false
+      fields:
+        - field: "@timestamp"
+        - field: "agent.id"
+        - field: "destination.ip"
+        - field: "event.category"
+        - field: "event.dataset"
+        - field: "event.module"
+        - field: "event.outcome"
+        - field: "file.hash.sha256"
+        - field: "file.name"
+        - field: "file.path"
+        - field: "host.name"
+        - field: "host.os.name"
+        - field: "host.os.version"
+        - field: "kibana.alert.original_time"
+        - field: "kibana.alert.risk_score"
+        - field: "kibana.alert.rule.description"
+        - field: "kibana.alert.rule.name"
+        - field: "kibana.alert.rule.references"
+        - field: "kibana.alert.rule.threat.framework"
+        - field: "kibana.alert.rule.threat.tactic.id"
+        - field: "kibana.alert.rule.threat.tactic.name"
+        - field: "kibana.alert.rule.threat.tactic.reference"
+        - field: "kibana.alert.rule.threat.technique.id"
+        - field: "kibana.alert.rule.threat.technique.name"
+        - field: "kibana.alert.rule.threat.technique.reference"
+        - field: "kibana.alert.rule.threat.technique.subtechnique.id"
+        - field: "kibana.alert.rule.threat.technique.subtechnique.name"
+        - field: "kibana.alert.rule.threat.technique.subtechnique.reference"
+        - field: "kibana.alert.severity"
+        - field: "kibana.alert.workflow_status"
+        - field: "message"
+        - field: "network.protocol"
+        - field: "process.args"
+        - field: "process.command_line"
+        - field: "process.executable"
+        - field: "process.hash.sha256"
+        - field: "process.name"
+        - field: "process.pid"
+        - field: "process.parent.command_line"
+        - field: "process.parent.executable"
+        - field: "process.parent.name"
+        - field: "source.ip"
+        - field: "user.domain"
+        - field: "user.name"
+      query:
+        bool:
+          filter:
+            - bool:
+                must: []
+                filter:
+                  # Only open or acknowledged alerts
+                  - bool:
+                      should:
+                        - match_phrase:
+                            kibana.alert.workflow_status:
+                              query: "open"
+                        - match_phrase:
+                            kibana.alert.workflow_status:
+                              query: "acknowledged"
+                      minimum_should_match: 1
+                  # Time range filter (supports date math like now-24h)
+                  - range:
+                      '@timestamp':
+                        gte: '${{ inputs.start }}'
+                        lte: '${{ inputs.end }}'
+                        format: strict_date_optional_time
+                should: []
+                # Exclude building block alerts
+                must_not:
+                  - exists:
+                      field: kibana.alert.building_block_type
+      # NOTE: Sort is intentionally omitted. The workflow JSON schema
+      # flattens body and URL query params for elasticsearch.search,
+      # and the URL query param `sort` type (string-only) overrides
+      # the body `sort` type (which supports objects with order).
+      # This means we cannot express `sort: [{ risk_score: desc }]`
+      # in a schema-compliant way. The original TypeScript query
+      # sorts by risk_score DESC then @timestamp DESC. Without
+      # explicit sort, Elasticsearch returns results in index order
+      # for filter-only queries. This is acceptable for a test
+      # workflow whose purpose is to exercise the normalization
+      # pipeline, not to validate sort order.

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/validate_bundled_workflow_definitions.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/definitions/validate_bundled_workflow_definitions.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { parseDocument } from 'yaml';
+import { validateLiquidTemplate } from '@kbn/workflows-management-plugin/common/lib/validate_liquid_template';
+
+const DEFINITIONS_DIR = __dirname;
+
+const getWorkflowYamlFiles = (): Array<{ fileName: string; content: string }> =>
+  readdirSync(DEFINITIONS_DIR)
+    .filter((f) => f.endsWith('.workflow.yaml'))
+    .sort()
+    .map((fileName) => ({
+      content: readFileSync(join(DEFINITIONS_DIR, fileName), 'utf-8'),
+      fileName,
+    }));
+
+describe('bundled workflow definitions', () => {
+  const workflowFiles = getWorkflowYamlFiles();
+
+  it('should discover at least one workflow YAML file', () => {
+    expect(workflowFiles.length).toBeGreaterThan(0);
+  });
+
+  describe('concurrency settings', () => {
+    it('the attack_discovery_generation workflow should not have concurrency limits', () => {
+      const generationWorkflow = workflowFiles.find(
+        ({ fileName }) => fileName === 'attack_discovery_generation.workflow.yaml'
+      );
+      expect(generationWorkflow).toBeDefined();
+
+      const parsed = parseDocument(generationWorkflow!.content).toJSON();
+      expect(parsed.settings?.concurrency).toBeUndefined();
+    });
+  });
+
+  describe('liquid template validation', () => {
+    workflowFiles.forEach(({ fileName, content }) => {
+      it(`${fileName} should contain no Liquid template errors`, () => {
+        const yamlDocument = parseDocument(content);
+        const errors = validateLiquidTemplate(content, yamlDocument);
+
+        expect(errors).toEqual([]);
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/helpers/read_bundled_workflow_yaml/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/helpers/read_bundled_workflow_yaml/index.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { readFileSync } from 'fs';
+
+import type { Logger } from '@kbn/core/server';
+
+/**
+ * Reads a bundled workflow YAML file from the given absolute path.
+ * Returns the trimmed YAML content, or null if the file cannot be read.
+ */
+export const readBundledWorkflowYaml = ({
+  logger,
+  yamlFileName,
+  yamlPath,
+}: {
+  logger: Logger;
+  yamlFileName: string;
+  yamlPath: string;
+}): string | null => {
+  try {
+    return readFileSync(yamlPath, 'utf-8').trim();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(`Failed to read bundled workflow YAML '${yamlFileName}': ${message}`);
+    return null;
+  }
+};

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/helpers/resolve_connector_details/index.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/helpers/resolve_connector_details/index.test.ts
@@ -1,0 +1,271 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+import type { InferenceServerStart } from '@kbn/inference-plugin/server';
+
+import { resolveConnectorDetails } from '.';
+
+describe('resolveConnectorDetails', () => {
+  const mockLogger = {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  } as unknown as Logger;
+
+  const mockActionsClient = {
+    get: jest.fn(),
+  };
+
+  const mockRequest = {} as KibanaRequest;
+
+  const connectorId = 'connector-1';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockActionsClient.get.mockResolvedValue({
+      actionTypeId: '.gen-ai',
+      id: connectorId,
+      name: 'My OpenAI Connector',
+    });
+  });
+
+  describe('when both actionTypeId and connectorName are provided', () => {
+    it('returns the provided values without calling actionsClient.get', async () => {
+      const result = await resolveConnectorDetails({
+        actionsClient: mockActionsClient,
+        actionTypeId: '.bedrock',
+        connectorId,
+        connectorName: 'Existing Name',
+        logger: mockLogger,
+      });
+
+      expect(result).toEqual({
+        actionTypeId: '.bedrock',
+        connectorName: 'Existing Name',
+      });
+      expect(mockActionsClient.get).not.toHaveBeenCalled();
+    });
+
+    it('does not call inference.getConnectorById when both values are already provided', async () => {
+      const mockGetConnectorById = jest.fn();
+      const mockInference = {
+        getConnectorById: mockGetConnectorById,
+      } as unknown as InferenceServerStart;
+
+      await resolveConnectorDetails({
+        actionsClient: mockActionsClient,
+        actionTypeId: '.bedrock',
+        connectorId,
+        connectorName: 'Existing Name',
+        inference: mockInference,
+        logger: mockLogger,
+        request: mockRequest,
+      });
+
+      expect(mockGetConnectorById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when actionTypeId is missing', () => {
+    it('resolves actionTypeId from actionsClient.get', async () => {
+      const result = await resolveConnectorDetails({
+        actionsClient: mockActionsClient,
+        connectorId,
+        connectorName: 'Existing Name',
+        logger: mockLogger,
+      });
+
+      expect(result).toEqual({
+        actionTypeId: '.gen-ai',
+        connectorName: 'Existing Name',
+      });
+      expect(mockActionsClient.get).toHaveBeenCalledWith({ id: connectorId });
+    });
+  });
+
+  describe('when connectorName is missing', () => {
+    it('resolves connectorName from actionsClient.get', async () => {
+      const result = await resolveConnectorDetails({
+        actionsClient: mockActionsClient,
+        actionTypeId: '.bedrock',
+        connectorId,
+        logger: mockLogger,
+      });
+
+      expect(result).toEqual({
+        actionTypeId: '.bedrock',
+        connectorName: 'My OpenAI Connector',
+      });
+      expect(mockActionsClient.get).toHaveBeenCalledWith({ id: connectorId });
+    });
+  });
+
+  describe('when both actionTypeId and connectorName are missing', () => {
+    it('resolves both from actionsClient.get', async () => {
+      const result = await resolveConnectorDetails({
+        actionsClient: mockActionsClient,
+        connectorId,
+        logger: mockLogger,
+      });
+
+      expect(result).toEqual({
+        actionTypeId: '.gen-ai',
+        connectorName: 'My OpenAI Connector',
+      });
+      expect(mockActionsClient.get).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when actionsClient.get fails', () => {
+    beforeEach(() => {
+      mockActionsClient.get.mockRejectedValue(new Error('Connector not found'));
+    });
+
+    it('throws when actionTypeId is missing and lookup fails', async () => {
+      await expect(
+        resolveConnectorDetails({
+          actionsClient: mockActionsClient,
+          connectorId,
+          logger: mockLogger,
+        })
+      ).rejects.toThrow(
+        `Failed to resolve connector details for ${connectorId}: Connector not found`
+      );
+    });
+
+    it('throws when connectorName is missing and lookup fails', async () => {
+      await expect(
+        resolveConnectorDetails({
+          actionsClient: mockActionsClient,
+          actionTypeId: '.gen-ai',
+          connectorId,
+          logger: mockLogger,
+        })
+      ).rejects.toThrow(
+        `Failed to resolve connector details for ${connectorId}: Connector not found`
+      );
+    });
+  });
+
+  describe('when inference plugin is available', () => {
+    const mockGetConnectorById = jest.fn();
+    let mockInference: InferenceServerStart;
+
+    beforeEach(() => {
+      mockGetConnectorById.mockResolvedValue({
+        type: '.inference',
+        name: 'EIS Anthropic Claude',
+      });
+      mockInference = { getConnectorById: mockGetConnectorById } as unknown as InferenceServerStart;
+    });
+
+    it('uses inference.getConnectorById instead of actionsClient.get', async () => {
+      await resolveConnectorDetails({
+        actionsClient: mockActionsClient,
+        connectorId: '.anthropic-claude-4.6-opus-chat_completion',
+        inference: mockInference,
+        logger: mockLogger,
+        request: mockRequest,
+      });
+
+      expect(mockGetConnectorById).toHaveBeenCalledWith(
+        '.anthropic-claude-4.6-opus-chat_completion',
+        mockRequest
+      );
+      expect(mockActionsClient.get).not.toHaveBeenCalled();
+    });
+
+    it('resolves actionTypeId from inference connector type', async () => {
+      const result = await resolveConnectorDetails({
+        actionsClient: mockActionsClient,
+        connectorId: '.anthropic-claude-4.6-opus-chat_completion',
+        inference: mockInference,
+        logger: mockLogger,
+        request: mockRequest,
+      });
+
+      expect(result.actionTypeId).toBe('.inference');
+    });
+
+    it('resolves connectorName from inference connector name', async () => {
+      const result = await resolveConnectorDetails({
+        actionsClient: mockActionsClient,
+        connectorId: '.anthropic-claude-4.6-opus-chat_completion',
+        inference: mockInference,
+        logger: mockLogger,
+        request: mockRequest,
+      });
+
+      expect(result.connectorName).toBe('EIS Anthropic Claude');
+    });
+
+    it('preserves provided actionTypeId when resolving connectorName via inference', async () => {
+      const result = await resolveConnectorDetails({
+        actionsClient: mockActionsClient,
+        actionTypeId: '.bedrock',
+        connectorId,
+        inference: mockInference,
+        logger: mockLogger,
+        request: mockRequest,
+      });
+
+      expect(result.actionTypeId).toBe('.bedrock');
+    });
+
+    it('preserves provided connectorName when resolving actionTypeId via inference', async () => {
+      const result = await resolveConnectorDetails({
+        actionsClient: mockActionsClient,
+        connectorId,
+        connectorName: 'My Custom Name',
+        inference: mockInference,
+        logger: mockLogger,
+        request: mockRequest,
+      });
+
+      expect(result.connectorName).toBe('My Custom Name');
+    });
+
+    it('throws when inference.getConnectorById fails', async () => {
+      mockGetConnectorById.mockRejectedValue(new Error('EIS endpoint not found'));
+
+      await expect(
+        resolveConnectorDetails({
+          actionsClient: mockActionsClient,
+          connectorId: '.anthropic-claude-4.6-opus-chat_completion',
+          inference: mockInference,
+          logger: mockLogger,
+          request: mockRequest,
+        })
+      ).rejects.toThrow(
+        'Failed to resolve connector details for .anthropic-claude-4.6-opus-chat_completion: EIS endpoint not found'
+      );
+    });
+  });
+
+  describe('when inference plugin is available but request is missing', () => {
+    it('falls back to actionsClient.get when request is not provided', async () => {
+      const mockGetConnectorById = jest.fn();
+      const mockInference = {
+        getConnectorById: mockGetConnectorById,
+      } as unknown as InferenceServerStart;
+
+      await resolveConnectorDetails({
+        actionsClient: mockActionsClient,
+        connectorId,
+        inference: mockInference,
+        logger: mockLogger,
+        // request intentionally omitted
+      });
+
+      expect(mockGetConnectorById).not.toHaveBeenCalled();
+      expect(mockActionsClient.get).toHaveBeenCalledWith({ id: connectorId });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/helpers/resolve_connector_details/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/helpers/resolve_connector_details/index.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+import type { InferenceServerStart } from '@kbn/inference-plugin/server';
+
+interface ActionsClientLike {
+  get: (params: { id: string }) => Promise<{ actionTypeId: string; name: string }>;
+}
+
+/**
+ * Resolves `actionTypeId` and `connectorName` from `connector_id`.
+ *
+ * Resolution order:
+ * 1. Both `actionTypeId` and `connectorName` already provided → return immediately (no I/O).
+ * 2. `inference` + `request` provided → use `inference.getConnectorById()`, which handles
+ *    both stack connectors and EIS endpoint IDs (e.g. `.anthropic-claude-4.6-opus-chat_completion`).
+ * 3. No inference → use `actionsClient.get()` (stack connectors only, existing fallback).
+ */
+export const resolveConnectorDetails = async ({
+  actionsClient,
+  actionTypeId,
+  connectorId,
+  connectorName,
+  inference,
+  logger,
+  request,
+}: {
+  actionsClient: ActionsClientLike;
+  actionTypeId?: string;
+  connectorId: string;
+  connectorName?: string;
+  inference?: InferenceServerStart;
+  logger: Logger;
+  request?: KibanaRequest;
+}): Promise<{ actionTypeId: string; connectorName: string }> => {
+  if (actionTypeId != null && connectorName != null) {
+    return { actionTypeId, connectorName };
+  }
+
+  logger.debug(
+    () =>
+      `Resolving connector details for ${connectorId} (actionTypeId=${
+        actionTypeId ?? 'missing'
+      }, connectorName=${connectorName ?? 'missing'})`
+  );
+
+  if (inference != null && request != null) {
+    try {
+      const connector = await inference.getConnectorById(connectorId, request);
+
+      return {
+        actionTypeId: actionTypeId ?? connector.type,
+        connectorName: connectorName ?? connector.name,
+      };
+    } catch (error) {
+      throw new Error(
+        `Failed to resolve connector details for ${connectorId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  try {
+    const connector = await actionsClient.get({ id: connectorId });
+
+    return {
+      actionTypeId: actionTypeId ?? connector.actionTypeId,
+      connectorName: connectorName ?? connector.name,
+    };
+  } catch (error) {
+    throw new Error(
+      `Failed to resolve connector details for ${connectorId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+};

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/register_default_workflows.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/register_default_workflows.test.ts
@@ -1,0 +1,359 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import type { KibanaRequest } from '@kbn/core/server';
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+
+import { registerDefaultWorkflows } from './register_default_workflows';
+
+jest.mock('fs', () => ({
+  readFileSync: jest.fn().mockReturnValue('mock yaml content'),
+}));
+
+const mockGetWorkflows = jest.fn();
+const mockCreateWorkflow = jest.fn();
+const mockGetWorkflow = jest.fn();
+const mockUpdateWorkflow = jest.fn();
+
+const mockWorkflowsManagementApi = {
+  createWorkflow: mockCreateWorkflow,
+  getWorkflow: mockGetWorkflow,
+  getWorkflows: mockGetWorkflows,
+  updateWorkflow: mockUpdateWorkflow,
+} as unknown as WorkflowsServerPluginSetup['management'];
+
+const mockLogger = loggerMock.create();
+const mockRequest = {} as KibanaRequest;
+const mockSpaceId = 'default';
+
+const REQUIRED_WORKFLOW_KEYS = ['default_alert_retrieval', 'generation', 'validate'] as const;
+const ALL_WORKFLOW_KEYS = [
+  'custom_validation_example',
+  'default_alert_retrieval',
+  'esql_example_alert_retrieval',
+  'generation',
+  'run_example',
+  'validate',
+] as const;
+
+/** Returns an empty workflow list (no existing workflows). */
+const emptyWorkflowList = () => ({ results: [], total: 0 });
+
+/** Returns a workflow list containing one workflow with the given id. */
+const workflowListWith = (id: string) => ({ results: [{ id }], total: 1 });
+
+/** Returns a workflow object with the given id and yaml. */
+const workflowWith = (id: string, yaml = 'mock yaml content') => ({ id, yaml });
+
+/** Sets up mockGetWorkflows and mockCreateWorkflow for the happy path (all new workflows). */
+const setupNewWorkflowsHappyPath = () => {
+  mockGetWorkflows.mockResolvedValue(emptyWorkflowList());
+  ALL_WORKFLOW_KEYS.forEach((key, i) => {
+    mockCreateWorkflow.mockResolvedValueOnce({ id: `created-id-${key}-${i}` });
+  });
+};
+
+describe('registerDefaultWorkflows', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    const { readFileSync } = jest.requireMock('fs');
+    readFileSync.mockReturnValue('mock yaml content');
+  });
+
+  describe('happy path — all workflows are new', () => {
+    it('returns workflow IDs for all required keys', async () => {
+      setupNewWorkflowsHappyPath();
+
+      const result = await registerDefaultWorkflows(
+        mockWorkflowsManagementApi,
+        mockSpaceId,
+        mockLogger,
+        mockRequest
+      );
+
+      for (const key of REQUIRED_WORKFLOW_KEYS) {
+        expect(result[key]).toBeDefined();
+        expect(typeof result[key]).toBe('string');
+      }
+    });
+
+    it('calls createWorkflow once per workflow definition', async () => {
+      setupNewWorkflowsHappyPath();
+
+      await registerDefaultWorkflows(
+        mockWorkflowsManagementApi,
+        mockSpaceId,
+        mockLogger,
+        mockRequest
+      );
+
+      expect(mockCreateWorkflow).toHaveBeenCalledTimes(ALL_WORKFLOW_KEYS.length);
+    });
+
+    it('calls createWorkflow with the YAML content read from disk', async () => {
+      setupNewWorkflowsHappyPath();
+
+      await registerDefaultWorkflows(
+        mockWorkflowsManagementApi,
+        mockSpaceId,
+        mockLogger,
+        mockRequest
+      );
+
+      expect(mockCreateWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({ yaml: 'mock yaml content' }),
+        mockSpaceId,
+        mockRequest
+      );
+    });
+
+    it('does not call getWorkflow or updateWorkflow when all workflows are new', async () => {
+      setupNewWorkflowsHappyPath();
+
+      await registerDefaultWorkflows(
+        mockWorkflowsManagementApi,
+        mockSpaceId,
+        mockLogger,
+        mockRequest
+      );
+
+      expect(mockGetWorkflow).not.toHaveBeenCalled();
+      expect(mockUpdateWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('logs info after registration is complete', async () => {
+      setupNewWorkflowsHappyPath();
+
+      await registerDefaultWorkflows(
+        mockWorkflowsManagementApi,
+        mockSpaceId,
+        mockLogger,
+        mockRequest
+      );
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Default workflow registration complete')
+      );
+    });
+  });
+
+  describe('happy path — workflows already exist with matching YAML', () => {
+    it('returns the existing workflow IDs without calling createWorkflow', async () => {
+      for (const key of ALL_WORKFLOW_KEYS) {
+        mockGetWorkflows.mockResolvedValueOnce(workflowListWith(`existing-id-${key}`));
+        mockGetWorkflow.mockResolvedValueOnce(
+          workflowWith(`existing-id-${key}`, 'mock yaml content')
+        );
+      }
+
+      const result = await registerDefaultWorkflows(
+        mockWorkflowsManagementApi,
+        mockSpaceId,
+        mockLogger,
+        mockRequest
+      );
+
+      expect(mockCreateWorkflow).not.toHaveBeenCalled();
+      expect(result.default_alert_retrieval).toBe('existing-id-default_alert_retrieval');
+      expect(result.generation).toBe('existing-id-generation');
+      expect(result.validate).toBe('existing-id-validate');
+    });
+
+    it('does not call updateWorkflow when existing YAML matches bundled YAML', async () => {
+      for (const key of ALL_WORKFLOW_KEYS) {
+        mockGetWorkflows.mockResolvedValueOnce(workflowListWith(`existing-id-${key}`));
+        mockGetWorkflow.mockResolvedValueOnce(
+          workflowWith(`existing-id-${key}`, 'mock yaml content')
+        );
+      }
+
+      await registerDefaultWorkflows(
+        mockWorkflowsManagementApi,
+        mockSpaceId,
+        mockLogger,
+        mockRequest
+      );
+
+      expect(mockUpdateWorkflow).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update path — existing workflow YAML differs from bundled YAML', () => {
+    it('calls updateWorkflow when existing YAML differs from bundled YAML', async () => {
+      for (const key of ALL_WORKFLOW_KEYS) {
+        mockGetWorkflows.mockResolvedValueOnce(workflowListWith(`existing-id-${key}`));
+        mockGetWorkflow.mockResolvedValueOnce(
+          workflowWith(`existing-id-${key}`, 'old yaml content')
+        );
+      }
+
+      await registerDefaultWorkflows(
+        mockWorkflowsManagementApi,
+        mockSpaceId,
+        mockLogger,
+        mockRequest
+      );
+
+      expect(mockUpdateWorkflow).toHaveBeenCalledTimes(ALL_WORKFLOW_KEYS.length);
+    });
+
+    it('calls updateWorkflow with the new YAML content', async () => {
+      mockGetWorkflows.mockResolvedValue(workflowListWith('existing-id'));
+      mockGetWorkflow.mockResolvedValue(workflowWith('existing-id', 'old yaml content'));
+
+      await registerDefaultWorkflows(
+        mockWorkflowsManagementApi,
+        mockSpaceId,
+        mockLogger,
+        mockRequest
+      );
+
+      expect(mockUpdateWorkflow).toHaveBeenCalledWith(
+        'existing-id',
+        expect.objectContaining({ yaml: 'mock yaml content' }),
+        mockSpaceId,
+        mockRequest
+      );
+    });
+
+    it('logs a warning when updateWorkflow throws, but does not rethrow', async () => {
+      mockGetWorkflows.mockResolvedValue(workflowListWith('existing-id'));
+      mockGetWorkflow.mockResolvedValue(workflowWith('existing-id', 'old yaml content'));
+      mockUpdateWorkflow.mockRejectedValue(new Error('update failed'));
+
+      await expect(
+        registerDefaultWorkflows(mockWorkflowsManagementApi, mockSpaceId, mockLogger, mockRequest)
+      ).resolves.toBeDefined();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('update failed'));
+    });
+  });
+
+  describe('error path — getWorkflows throws', () => {
+    it('rethrows when getWorkflows fails for a required workflow key', async () => {
+      mockGetWorkflows.mockRejectedValue(new Error('ES unavailable'));
+
+      await expect(
+        registerDefaultWorkflows(mockWorkflowsManagementApi, mockSpaceId, mockLogger, mockRequest)
+      ).rejects.toThrow('ES unavailable');
+    });
+
+    it('logs an error when getWorkflows fails for a required workflow key', async () => {
+      mockGetWorkflows.mockRejectedValue(new Error('ES unavailable'));
+
+      await expect(
+        registerDefaultWorkflows(mockWorkflowsManagementApi, mockSpaceId, mockLogger, mockRequest)
+      ).rejects.toThrow();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('ES unavailable'));
+    });
+
+    it('continues registration and returns required IDs when an optional workflow fails', async () => {
+      // custom_validation_example (index 0 in DEFAULT_WORKFLOWS) is optional — throw for it
+      // all other workflows succeed
+      mockGetWorkflows
+        .mockRejectedValueOnce(new Error('optional workflow failed')) // custom_validation_example
+        .mockResolvedValue(emptyWorkflowList()); // default_alert_retrieval, esql_example, generation, run_example, validate
+
+      let callCount = 0;
+      mockCreateWorkflow.mockImplementation(() => {
+        callCount += 1;
+        return Promise.resolve({ id: `created-id-${callCount}` });
+      });
+
+      const result = await registerDefaultWorkflows(
+        mockWorkflowsManagementApi,
+        mockSpaceId,
+        mockLogger,
+        mockRequest
+      );
+
+      expect(result.default_alert_retrieval).toBeDefined();
+      expect(result.generation).toBeDefined();
+      expect(result.validate).toBeDefined();
+    });
+
+    it('logs error but does not rethrow when an optional workflow fails', async () => {
+      mockGetWorkflows
+        .mockRejectedValueOnce(new Error('optional workflow failed')) // custom_validation_example (optional)
+        .mockResolvedValue(emptyWorkflowList());
+
+      let callCount = 0;
+      mockCreateWorkflow.mockImplementation(() => {
+        callCount += 1;
+        return Promise.resolve({ id: `created-id-${callCount}` });
+      });
+
+      await registerDefaultWorkflows(
+        mockWorkflowsManagementApi,
+        mockSpaceId,
+        mockLogger,
+        mockRequest
+      );
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('optional workflow failed')
+      );
+    });
+  });
+
+  describe('error path — createWorkflow throws', () => {
+    it('rethrows when createWorkflow fails for a required workflow key', async () => {
+      // All getWorkflows return empty (no existing), createWorkflow throws for the first required
+      mockGetWorkflows.mockResolvedValue(emptyWorkflowList());
+      mockCreateWorkflow.mockRejectedValue(new Error('create failed'));
+
+      await expect(
+        registerDefaultWorkflows(mockWorkflowsManagementApi, mockSpaceId, mockLogger, mockRequest)
+      ).rejects.toThrow('create failed');
+    });
+
+    it('logs an error when createWorkflow fails', async () => {
+      mockGetWorkflows.mockResolvedValue(emptyWorkflowList());
+      mockCreateWorkflow.mockRejectedValue(new Error('create failed'));
+
+      await expect(
+        registerDefaultWorkflows(mockWorkflowsManagementApi, mockSpaceId, mockLogger, mockRequest)
+      ).rejects.toThrow();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('create failed'));
+    });
+  });
+
+  describe('error path — YAML file unreadable', () => {
+    it('throws when bundled YAML is unreadable for a required workflow', async () => {
+      const { readFileSync } = jest.requireMock('fs');
+      readFileSync.mockImplementation(() => {
+        throw new Error('ENOENT: file not found');
+      });
+
+      mockGetWorkflows.mockResolvedValue(emptyWorkflowList());
+
+      await expect(
+        registerDefaultWorkflows(mockWorkflowsManagementApi, mockSpaceId, mockLogger, mockRequest)
+      ).rejects.toThrow(/unavailable.*cannot create/i);
+    });
+
+    it('logs a warning when bundled YAML is unreadable', async () => {
+      const { readFileSync } = jest.requireMock('fs');
+      readFileSync.mockImplementation(() => {
+        throw new Error('ENOENT: file not found');
+      });
+
+      mockGetWorkflows.mockResolvedValue(emptyWorkflowList());
+
+      await expect(
+        registerDefaultWorkflows(mockWorkflowsManagementApi, mockSpaceId, mockLogger, mockRequest)
+      ).rejects.toThrow();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to read bundled workflow YAML')
+      );
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/register_default_workflows.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/register_default_workflows.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { join } from 'path';
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+import type { WorkflowListDto } from '@kbn/workflows';
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+import { readBundledWorkflowYaml } from './helpers/read_bundled_workflow_yaml';
+
+interface DefaultWorkflowDefinition {
+  key:
+    | 'custom_validation_example'
+    | 'default_alert_retrieval'
+    | 'esql_example_alert_retrieval'
+    | 'generation'
+    | 'run_example'
+    | 'validate';
+  searchTag: string;
+  yamlPath: string;
+}
+
+/**
+ * Default Attack Discovery workflows to register on plugin startup.
+ * These workflows are available immediately when the feature flag is enabled.
+ */
+const DEFAULT_WORKFLOWS: DefaultWorkflowDefinition[] = [
+  {
+    key: 'custom_validation_example',
+    searchTag: 'attackDiscovery:custom_validation_example',
+    yamlPath: 'attack_discovery_custom_validation_example.workflow.yaml',
+  },
+  {
+    key: 'default_alert_retrieval',
+    searchTag: 'attackDiscovery:default_alert_retrieval',
+    yamlPath: 'default_attack_discovery_alert_retrieval.workflow.yaml',
+  },
+  {
+    key: 'esql_example_alert_retrieval',
+    searchTag: 'attackDiscovery:esql_example_alert_retrieval',
+    yamlPath: 'attack_discovery_esql_example.workflow.yaml',
+  },
+  {
+    key: 'generation',
+    searchTag: 'attackDiscovery:generation',
+    yamlPath: 'attack_discovery_generation.workflow.yaml',
+  },
+  {
+    key: 'run_example',
+    searchTag: 'attackDiscovery:run_example',
+    yamlPath: 'attack_discovery_run_example.workflow.yaml',
+  },
+  {
+    key: 'validate',
+    searchTag: 'attackDiscovery:validate',
+    yamlPath: 'attack_discovery_validate.workflow.yaml',
+  },
+];
+
+export type DefaultWorkflowKey = DefaultWorkflowDefinition['key'];
+
+type RequiredDefaultWorkflowKey = 'default_alert_retrieval' | 'generation' | 'validate';
+type OptionalDefaultWorkflowKey = Exclude<DefaultWorkflowKey, RequiredDefaultWorkflowKey>;
+
+export type DefaultWorkflowIds = Record<RequiredDefaultWorkflowKey, string> &
+  Partial<Record<OptionalDefaultWorkflowKey, string>>;
+
+const REQUIRED_WORKFLOW_KEYS: ReadonlySet<RequiredDefaultWorkflowKey> = new Set([
+  'default_alert_retrieval',
+  'generation',
+  'validate',
+]);
+
+const getFirstWorkflowIdForTag = ({ workflows }: { workflows: WorkflowListDto }): string | null =>
+  workflows.results[0]?.id ?? null;
+
+/**
+ * Registers default Attack Discovery workflows on plugin startup.
+ * Workflows are created if they don't exist, or skipped if already present.
+ *
+ * @param workflowsManagementApi - The workflows management API
+ * @param spaceId - The space ID to register workflows in (defaults to 'default')
+ * @param logger - Logger instance
+ * @param request - The authenticated request used for workflow creation/update
+ */
+export const registerDefaultWorkflows = async (
+  workflowsManagementApi: WorkflowsServerPluginSetup['management'],
+  spaceId: string,
+  logger: Logger,
+  request: KibanaRequest
+): Promise<DefaultWorkflowIds> => {
+  logger.debug(() => 'Starting default workflow registration');
+
+  const definitionsDir = join(__dirname, 'definitions');
+  const resolvedWorkflowIds = {} as Partial<Record<DefaultWorkflowKey, string>>;
+
+  for (const workflowDefinition of DEFAULT_WORKFLOWS) {
+    try {
+      const yamlPath = join(definitionsDir, workflowDefinition.yamlPath);
+      const readDesiredYaml = (): string | null =>
+        readBundledWorkflowYaml({
+          logger,
+          yamlFileName: workflowDefinition.yamlPath,
+          yamlPath,
+        });
+
+      let workflows: WorkflowListDto;
+      try {
+        workflows = await workflowsManagementApi.getWorkflows(
+          {
+            _full: false,
+            page: 1,
+            size: 100,
+            tags: [workflowDefinition.searchTag],
+          },
+          spaceId
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(
+          `🔴 discoveries: workflowsManagementApi.getWorkflows failed (key: '${workflowDefinition.key}', tag: '${workflowDefinition.searchTag}'): ${message}`
+        );
+        throw error;
+      }
+
+      const existingWorkflowId = getFirstWorkflowIdForTag({ workflows });
+
+      if (!existingWorkflowId) {
+        const desiredYaml = readDesiredYaml();
+        if (!desiredYaml) {
+          throw new Error(
+            `Bundled YAML '${workflowDefinition.yamlPath}' is unavailable; cannot create missing workflow '${workflowDefinition.key}'`
+          );
+        }
+
+        let createdWorkflow;
+        try {
+          createdWorkflow = await workflowsManagementApi.createWorkflow(
+            {
+              yaml: desiredYaml,
+            },
+            spaceId,
+            request
+          );
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          logger.error(
+            `🔴 discoveries: workflowsManagementApi.createWorkflow failed (key: '${workflowDefinition.key}'): ${message}`
+          );
+          throw error;
+        }
+
+        resolvedWorkflowIds[workflowDefinition.key] = createdWorkflow.id;
+        logger.info(
+          `Successfully registered workflow '${workflowDefinition.key}' as '${createdWorkflow.id}'`
+        );
+        continue;
+      }
+
+      let existingWorkflow = null;
+      try {
+        existingWorkflow = await workflowsManagementApi.getWorkflow(existingWorkflowId, spaceId);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(
+          `🔴 discoveries: workflowsManagementApi.getWorkflow failed (key: '${workflowDefinition.key}', id: '${existingWorkflowId}'): ${message}`
+        );
+        throw error;
+      }
+
+      if (!existingWorkflow) {
+        throw new Error(
+          `Found workflow id '${existingWorkflowId}' for tag '${workflowDefinition.searchTag}', but it no longer exists`
+        );
+      }
+
+      const existingYaml = existingWorkflow.yaml?.trim();
+
+      const desiredYaml = readDesiredYaml();
+      if (desiredYaml && existingYaml !== desiredYaml) {
+        logger.info(
+          `Workflow '${existingWorkflowId}' (${workflowDefinition.key}) differs from bundled YAML; attempting update`
+        );
+
+        try {
+          await workflowsManagementApi.updateWorkflow(
+            existingWorkflowId,
+            { yaml: desiredYaml },
+            spaceId,
+            request
+          );
+          logger.info(
+            `Successfully updated workflow '${existingWorkflowId}' (${workflowDefinition.key})`
+          );
+        } catch (updateError) {
+          const updateMessage =
+            updateError instanceof Error ? updateError.message : String(updateError);
+          logger.warn(
+            `Failed to auto-update workflow '${existingWorkflowId}' (${workflowDefinition.key}): ${updateMessage}. The workflow will continue to use the previously stored YAML.`
+          );
+        }
+      }
+
+      resolvedWorkflowIds[workflowDefinition.key] = existingWorkflowId;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const stack = error instanceof Error ? error.stack : undefined;
+      logger.error(
+        `🔴 discoveries: Failed to ensure workflow '${workflowDefinition.key}': ${stack ?? message}`
+      );
+      if (REQUIRED_WORKFLOW_KEYS.has(workflowDefinition.key as RequiredDefaultWorkflowKey)) {
+        throw error;
+      }
+    }
+  }
+
+  const missingRequired = Array.from(REQUIRED_WORKFLOW_KEYS).filter(
+    (key) => !resolvedWorkflowIds[key]
+  );
+  if (missingRequired.length > 0) {
+    throw new Error(`Missing required default workflows: ${missingRequired.join(', ')}`);
+  }
+
+  logger.info('Default workflow registration complete');
+  return resolvedWorkflowIds as DefaultWorkflowIds;
+};

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/register_workflow_steps.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/register_workflow_steps.test.ts
@@ -1,0 +1,208 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
+import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
+import { registerWorkflowSteps } from './register_workflow_steps';
+
+describe('registerWorkflowSteps', () => {
+  const mockLogger = loggerMock.create();
+  const mockRegisterStepDefinition = jest.fn();
+  const mockWorkflowsExtensions = {
+    registerStepDefinition: mockRegisterStepDefinition,
+  } as unknown as WorkflowsExtensionsServerPluginSetup;
+  const mockAdhocAttackDiscoveryDataClient = {} as IRuleDataClient;
+  const mockGetStartServices = jest.fn();
+  const mockGetEventLogger = jest.fn();
+  const mockGetEventLogIndex = jest.fn().mockResolvedValue('.kibana-event-log-*');
+  const mockWorkflowInitService = {
+    ensureWorkflowsForSpace: jest.fn(),
+    verifyAndRepairWorkflows: jest.fn(),
+  };
+
+  const defaultArgs = {
+    adhocAttackDiscoveryDataClient: mockAdhocAttackDiscoveryDataClient,
+    connectorTimeout: 60000,
+    getEventLogIndex: mockGetEventLogIndex,
+    getEventLogger: mockGetEventLogger,
+    getStartServices: mockGetStartServices,
+    logger: mockLogger,
+    workflowInitService: mockWorkflowInitService,
+  } as const;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockGetEventLogIndex.mockResolvedValue('.kibana-event-log-*');
+  });
+
+  it('registers default alert retrieval step definition', () => {
+    registerWorkflowSteps(mockWorkflowsExtensions, defaultArgs);
+
+    expect(mockRegisterStepDefinition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'attack-discovery.defaultAlertRetrieval',
+      })
+    );
+  });
+
+  it('registers default validation step definition', () => {
+    registerWorkflowSteps(mockWorkflowsExtensions, defaultArgs);
+
+    expect(mockRegisterStepDefinition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'attack-discovery.defaultValidation',
+      })
+    );
+  });
+
+  it('registers generate step definition', () => {
+    registerWorkflowSteps(mockWorkflowsExtensions, defaultArgs);
+
+    expect(mockRegisterStepDefinition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'attack-discovery.generate',
+      })
+    );
+  });
+
+  it('registers persist discoveries step definition', () => {
+    registerWorkflowSteps(mockWorkflowsExtensions, defaultArgs);
+
+    expect(mockRegisterStepDefinition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'attack-discovery.persistDiscoveries',
+      })
+    );
+  });
+
+  it('registers all five step definitions', () => {
+    registerWorkflowSteps(mockWorkflowsExtensions, defaultArgs);
+
+    expect(mockRegisterStepDefinition).toHaveBeenCalledTimes(5);
+  });
+
+  it('returns StepRegistrationResult with all registeredSteps and no failedSteps when all succeed', () => {
+    const result = registerWorkflowSteps(mockWorkflowsExtensions, defaultArgs);
+
+    expect(result.registeredSteps).toHaveLength(5);
+    expect(result.failedSteps).toHaveLength(0);
+  });
+
+  it('continues registering remaining steps when one step fails', () => {
+    let callCount = 0;
+    mockRegisterStepDefinition.mockImplementation(() => {
+      callCount += 1;
+      if (callCount === 1) {
+        throw new Error('simulated registration failure');
+      }
+    });
+
+    const result = registerWorkflowSteps(mockWorkflowsExtensions, defaultArgs);
+
+    expect(mockRegisterStepDefinition).toHaveBeenCalledTimes(5);
+    expect(result.registeredSteps).toHaveLength(4);
+    expect(result.failedSteps).toHaveLength(1);
+  });
+
+  it('includes the error message and step id in failedSteps when a step fails', () => {
+    mockRegisterStepDefinition.mockImplementationOnce(() => {
+      throw new Error('registration error');
+    });
+
+    const result = registerWorkflowSteps(mockWorkflowsExtensions, defaultArgs);
+
+    expect(result.failedSteps[0]).toMatchObject({
+      error: 'registration error',
+      id: expect.any(String),
+    });
+  });
+
+  it('logs ERROR for each failed step', () => {
+    mockRegisterStepDefinition.mockImplementationOnce(() => {
+      throw new Error('registration error');
+    });
+
+    registerWorkflowSteps(mockWorkflowsExtensions, defaultArgs);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('registration error'));
+  });
+
+  it('returns all failedSteps and no registeredSteps when all steps fail', () => {
+    mockRegisterStepDefinition.mockImplementation(() => {
+      throw new Error('all steps failed');
+    });
+
+    const result = registerWorkflowSteps(mockWorkflowsExtensions, defaultArgs);
+
+    expect(result.registeredSteps).toHaveLength(0);
+    expect(result.failedSteps).toHaveLength(5);
+  });
+
+  it('logs debug messages for each registered step', () => {
+    registerWorkflowSteps(mockWorkflowsExtensions, defaultArgs);
+
+    expect(mockLogger.debug).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('logs info when all steps succeed', () => {
+    registerWorkflowSteps(mockWorkflowsExtensions, defaultArgs);
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.stringContaining('All workflow steps registered successfully')
+    );
+  });
+
+  it('logs warn instead of info when some steps fail', () => {
+    mockRegisterStepDefinition.mockImplementationOnce(() => {
+      throw new Error('step failure');
+    });
+
+    registerWorkflowSteps(mockWorkflowsExtensions, defaultArgs);
+
+    expect(mockLogger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('All workflow steps registered successfully')
+    );
+    expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('failure'));
+  });
+
+  it('passes connectorTimeout to generate step definition', () => {
+    const connectorTimeout = 120000;
+
+    registerWorkflowSteps(mockWorkflowsExtensions, { ...defaultArgs, connectorTimeout });
+
+    expect(mockRegisterStepDefinition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'attack-discovery.generate',
+      })
+    );
+  });
+
+  it('passes langSmithApiKey to generate step definition', () => {
+    const langSmithApiKey = 'test-api-key';
+
+    registerWorkflowSteps(mockWorkflowsExtensions, { ...defaultArgs, langSmithApiKey });
+
+    expect(mockRegisterStepDefinition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'attack-discovery.generate',
+      })
+    );
+  });
+
+  it('passes langSmithProject to generate step definition', () => {
+    const langSmithProject = 'test-project';
+
+    registerWorkflowSteps(mockWorkflowsExtensions, { ...defaultArgs, langSmithProject });
+
+    expect(mockRegisterStepDefinition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'attack-discovery.generate',
+      })
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/register_workflow_steps.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/register_workflow_steps.ts
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
+import type { AnalyticsServiceSetup, Logger } from '@kbn/core/server';
+import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
+import type { CoreStart } from '@kbn/core/server';
+import type { IEventLogger } from '@kbn/event-log-plugin/server';
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+import type { DiscoveriesPluginStartDeps } from '../types';
+import type { WorkflowInitializationService } from '../lib/workflow_initialization';
+import { getDefaultAlertRetrievalStepDefinition } from './steps/default_alert_retrieval_step';
+import { getDefaultValidationStepDefinition } from './steps/default_validation_step';
+import { getGenerateStepDefinition } from './steps/generate_step';
+import { getPersistDiscoveriesStepDefinition } from './steps/persist_discoveries_step';
+import { getRunStepDefinition } from './steps/run_step';
+
+export interface StepRegistrationResult {
+  failedSteps: Array<{ error: string; id: string }>;
+  registeredSteps: string[];
+}
+
+type StepRegistrationOutcome =
+  | { error: string; id: string; success: false }
+  | { id: string; success: true };
+
+const tryRegisterStep = ({
+  logger,
+  stepDefinition,
+  workflowsExtensions,
+}: {
+  logger: Logger;
+  stepDefinition: { id: string };
+  workflowsExtensions: WorkflowsExtensionsServerPluginSetup;
+}): StepRegistrationOutcome => {
+  try {
+    workflowsExtensions.registerStepDefinition(
+      stepDefinition as Parameters<
+        WorkflowsExtensionsServerPluginSetup['registerStepDefinition']
+      >[0]
+    );
+    return { id: stepDefinition.id, success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(`Failed to register step '${stepDefinition.id}': ${message}`);
+    return { error: message, id: stepDefinition.id, success: false };
+  }
+};
+
+export const registerWorkflowSteps = (
+  workflowsExtensions: WorkflowsExtensionsServerPluginSetup,
+  {
+    adhocAttackDiscoveryDataClient,
+    analytics,
+    connectorTimeout,
+    getEventLogIndex,
+    getEventLogger,
+    getStartServices,
+    langSmithApiKey,
+    langSmithProject,
+    logger,
+    workflowInitService,
+    workflowsManagementApi,
+  }: {
+    adhocAttackDiscoveryDataClient: IRuleDataClient;
+    analytics?: AnalyticsServiceSetup;
+    connectorTimeout: number;
+    getEventLogIndex: () => Promise<string>;
+    getEventLogger: () => Promise<IEventLogger>;
+    getStartServices: () => Promise<{
+      coreStart: CoreStart;
+      pluginsStart: DiscoveriesPluginStartDeps;
+    }>;
+    langSmithApiKey?: string;
+    langSmithProject?: string;
+    logger: Logger;
+    workflowInitService: WorkflowInitializationService;
+    workflowsManagementApi?: WorkflowsServerPluginSetup['management'];
+  }
+): StepRegistrationResult => {
+  const defaultAlertRetrievalStepDef = getDefaultAlertRetrievalStepDefinition({
+    getEventLogIndex,
+    getEventLogger,
+    getStartServices,
+    logger,
+  });
+  logger.debug(
+    () =>
+      `Registering defaultAlertRetrievalStepDefinition with id: ${defaultAlertRetrievalStepDef.id}`
+  );
+  const defaultAlertRetrievalOutcome = tryRegisterStep({
+    logger,
+    stepDefinition: defaultAlertRetrievalStepDef,
+    workflowsExtensions,
+  });
+
+  const defaultValidationStepDef = getDefaultValidationStepDefinition({
+    getStartServices,
+    logger,
+  });
+  logger.debug(
+    () => `Registering defaultValidationStepDefinition with id: ${defaultValidationStepDef.id}`
+  );
+  const defaultValidationOutcome = tryRegisterStep({
+    logger,
+    stepDefinition: defaultValidationStepDef,
+    workflowsExtensions,
+  });
+
+  const persistDiscoveriesStepDef = getPersistDiscoveriesStepDefinition({
+    adhocAttackDiscoveryDataClient,
+    getStartServices,
+    logger,
+  });
+  logger.debug(
+    () => `Registering persistDiscoveriesStepDefinition with id: ${persistDiscoveriesStepDef.id}`
+  );
+  const persistDiscoveriesOutcome = tryRegisterStep({
+    logger,
+    stepDefinition: persistDiscoveriesStepDef,
+    workflowsExtensions,
+  });
+
+  const generateStepDef = getGenerateStepDefinition({
+    connectorTimeout,
+    getEventLogIndex,
+    getEventLogger,
+    getStartServices,
+    langSmithApiKey,
+    langSmithProject,
+    logger,
+  });
+  logger.debug(() => `Registering generateStepDefinition with id: ${generateStepDef.id}`);
+  const generateOutcome = tryRegisterStep({
+    logger,
+    stepDefinition: generateStepDef,
+    workflowsExtensions,
+  });
+
+  const runStepDef = getRunStepDefinition({
+    analytics,
+    getEventLogIndex,
+    getEventLogger,
+    getStartServices,
+    logger,
+    workflowInitService,
+    workflowsManagementApi,
+  });
+  logger.debug(() => `Registering runStepDefinition with id: ${runStepDef.id}`);
+  const runOutcome = tryRegisterStep({
+    logger,
+    stepDefinition: runStepDef,
+    workflowsExtensions,
+  });
+
+  const outcomes = [
+    defaultAlertRetrievalOutcome,
+    defaultValidationOutcome,
+    generateOutcome,
+    persistDiscoveriesOutcome,
+    runOutcome,
+  ];
+
+  const registeredSteps = outcomes
+    .filter((o): o is { id: string; success: true } => o.success)
+    .map((o) => o.id);
+
+  const failedSteps = outcomes
+    .filter((o): o is { error: string; id: string; success: false } => !o.success)
+    .map((o) => ({ error: o.error, id: o.id }));
+
+  if (failedSteps.length === 0) {
+    logger.info('All workflow steps registered successfully');
+  } else {
+    logger.warn(
+      `Workflow step registration completed with ${failedSteps.length} failure(s): ${failedSteps
+        .map((s) => s.id)
+        .join(', ')}`
+    );
+  }
+
+  return { failedSteps, registeredSteps };
+};

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/README.md
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/README.md
@@ -1,0 +1,266 @@
+# Attack Discovery Workflow Steps — Justification
+
+This document explains why each Attack Discovery step is registered as a workflow step rather than exposed as a REST endpoint. It targets the workflows-eng team reviewing the step registration PR.
+
+## Overview
+
+Attack Discovery registers **five** workflow step types. All five are implemented. Each step is a server-side `createServerStepDefinition` backed by a shared common definition in `common/step_types/`.
+
+| Step Type ID | Category | Status |
+|---|---|---|
+| `attack-discovery.defaultAlertRetrieval` | Elasticsearch | Implemented |
+| `attack-discovery.generate` | AI | Implemented |
+| `attack-discovery.defaultValidation` | Kibana | Implemented |
+| `attack-discovery.persistDiscoveries` | Kibana | Implemented |
+| `attack-discovery.run` | AI | Implemented |
+
+## Why Steps Instead of REST Endpoints
+
+All five steps share the same fundamental justification for being workflow steps rather than REST endpoints:
+
+1. **Composability**: Steps can be wired together in user-authored YAML workflows via Liquid expressions. A REST endpoint requires the caller to handle HTTP, authentication, error mapping, and response parsing — none of which are necessary when data flows between steps within a single workflow execution.
+2. **Observability**: Each step execution is visible in the Workflows app with inputs, outputs, timing, and status. A REST call from within a workflow would appear as an opaque HTTP request with no structured observability.
+3. **Timeout management**: The workflow engine manages step timeouts (`timeout` field in YAML). A REST call would need its own timeout handling, creating a nested timeout problem.
+4. **Authentication propagation**: Steps inherit the workflow execution's authentication context via `context.contextManager.getFakeRequest()`. A REST call would need to forward credentials explicitly.
+5. **Abort signal propagation**: The workflow engine passes an `AbortSignal` to each step (`context.abortSignal`). Steps can cancel long-running operations (e.g., LLM calls) when the workflow is cancelled. REST endpoints cannot receive abort signals from the workflow engine.
+
+---
+
+## Step 1: `attack-discovery.defaultAlertRetrieval`
+
+### Purpose
+
+Retrieves security alerts from Elasticsearch and anonymizes sensitive fields, producing `string[]` alert representations suitable for LLM consumption.
+
+### Consumer
+
+- **Default pipeline**: The `_generate` endpoint's orchestrator invokes the `default-attack-discovery-alert-retrieval` workflow, which contains this step.
+- **Scheduled generation**: The `workflowExecutor` invokes the same pipeline for alerting-framework-based schedules.
+
+### User Pattern
+
+```yaml
+steps:
+  - name: retrieve_alerts
+    type: attack-discovery.defaultAlertRetrieval
+    timeout: '5m'
+    with:
+      alerts_index_pattern: .alerts-security.alerts-default
+      anonymization_fields: ${{ inputs.anonymization_fields }}
+      api_config: ${{ inputs.api_config }}
+      size: 150
+```
+
+### Why Not a REST Endpoint
+
+Beyond the shared reasons above, alert retrieval has a specific justification: the **anonymization fields** are user-configurable and stored in a Kibana saved object index. A REST endpoint would need to accept these as a request parameter (bloating the API surface) or fetch them internally (removing configurability). As a step, the orchestrator fetches anonymization fields once and passes them as input, keeping the step stateless and testable.
+
+Additionally, the step supports two retrieval modes — DSL query and ES|QL query — selected by the presence of the `esql_query` input. This modal behavior is natural for a step (the workflow decides which inputs to provide) but awkward for a REST endpoint (which would need a mode parameter or two separate endpoints).
+
+### Inputs/Outputs Summary
+
+| Direction | Key Fields |
+|-----------|------------|
+| **Input** | `alerts_index_pattern`, `anonymization_fields`, `api_config`, `esql_query` (optional), `filter`, `size`, `start`/`end`, `replacements` |
+| **Output** | `alerts` (string[]), `anonymized_alerts` (Document[]), `replacements`, `api_config`, `connector_name`, `alerts_context_count` |
+
+---
+
+## Step 2: `attack-discovery.generate`
+
+### Purpose
+
+Invokes the LangGraph-based generation graph with pre-retrieved anonymized alerts to produce attack discovery objects.
+
+### Consumer
+
+- **Default pipeline**: The `attack-discovery-generation` workflow contains this step, invoked by the orchestrator after alert retrieval.
+- **Custom workflows**: Advanced users can compose this step with custom retrieval logic.
+
+### User Pattern
+
+```yaml
+steps:
+  - name: generate
+    type: attack-discovery.generate
+    timeout: '10m'
+    with:
+      alerts: ${{ steps.retrieve.output.alerts }}
+      api_config: ${{ inputs.api_config }}
+      replacements: ${{ steps.retrieve.output.replacements }}
+      type: attack_discovery
+```
+
+### Why Not a REST Endpoint
+
+The generation step wraps LangGraph execution, which is long-running (2–10 minutes) and benefits from the workflow engine's abort signal propagation. If generation were a REST endpoint called from within a workflow, cancelling the parent workflow would not cancel the in-flight LLM calls — the HTTP request would continue to completion, wasting LLM tokens and compute.
+
+The step also needs access to `actionsClient` (for connector execution), `savedObjectsClient`, and `esClient` — all of which require a scoped request. The workflow execution context provides this via `getFakeRequest()`. A REST endpoint would need to re-authenticate, adding latency and complexity.
+
+The `_generate/graph` endpoint (now removed) was the REST-endpoint equivalent of this step. It was removed precisely because it produced orphaned results and bypassed validation — problems that do not exist when generation is a composable step.
+
+### Inputs/Outputs Summary
+
+| Direction | Key Fields |
+|-----------|------------|
+| **Input** | `alerts` (string[], min 1), `api_config`, `replacements`, `size`, `type` |
+| **Output** | `attack_discoveries` (AttackDiscovery[] or null), `execution_uuid`, `replacements` |
+
+---
+
+## Step 3: `attack-discovery.defaultValidation`
+
+### Purpose
+
+Performs hallucination detection (verifying that alert IDs referenced in discoveries actually exist) and deduplication against previously persisted discoveries.
+
+### Consumer
+
+- **Default pipeline**: The `attack-discovery-validate` workflow's first step.
+- **Custom validation workflows**: Users can create workflows that add custom filtering logic before or after this step.
+
+### User Pattern
+
+```yaml
+steps:
+  - name: validate
+    type: attack-discovery.defaultValidation
+    with:
+      attack_discoveries: ${{ steps.generate.output.attack_discoveries }}
+      api_config: ${{ inputs.api_config }}
+      connector_name: ${{ inputs.connector_name }}
+      generation_uuid: ${{ steps.generate.output.execution_uuid }}
+      replacements: ${{ steps.generate.output.replacements }}
+```
+
+### Why Not a REST Endpoint
+
+Validation requires an Elasticsearch query to check whether referenced alert IDs exist — a server-side operation that needs the current user's permissions. As a step, it inherits the execution context's authentication. As a REST endpoint, it would need to be called with the user's credentials, and the caller would need to serialize and send the full list of attack discoveries over HTTP — potentially a large payload.
+
+More importantly, validation is a **mid-pipeline operation** that feeds directly into persistence. The tight coupling between "validate → persist" is natural in a workflow (one step's output flows to the next) but awkward across REST calls (the caller must receive validated results, then POST them to a persist endpoint).
+
+The `_validate` REST endpoint exists for backward compatibility but is not used by the workflow pipeline. Workflows use this step directly.
+
+### Inputs/Outputs Summary
+
+| Direction | Key Fields |
+|-----------|------------|
+| **Input** | `attack_discoveries`, `api_config`, `connector_name`, `generation_uuid`, `replacements`, `alerts_index_pattern` (optional) |
+| **Output** | `validated_discoveries`, `filtered_count`, `filter_reason` (optional) |
+
+---
+
+## Step 4: `attack-discovery.persistDiscoveries`
+
+### Purpose
+
+Writes validated attack discoveries to the ad-hoc Attack Discovery data store as alert documents, with deduplication against existing discoveries in the same space.
+
+### Consumer
+
+- **Default pipeline**: The `attack-discovery-validate` workflow's second step (after validation).
+- **Scheduled generation**: The `workflowExecutor` persists via the alerting framework's `alertsClient` instead, but uses the same underlying `validateAttackDiscoveries` function for deduplication logic.
+
+### User Pattern
+
+```yaml
+steps:
+  - name: persist
+    type: attack-discovery.persistDiscoveries
+    with:
+      attack_discoveries: ${{ steps.validate.output.validated_discoveries }}
+      anonymized_alerts: ${{ inputs.anonymized_alerts }}
+      api_config: ${{ inputs.api_config }}
+      connector_name: ${{ inputs.connector_name }}
+      generation_uuid: ${{ inputs.generation_uuid }}
+      alerts_context_count: ${{ inputs.alerts_context_count }}
+```
+
+### Why Not a REST Endpoint
+
+Persistence writes to the Attack Discovery alerts index using the ad-hoc `IRuleDataClient`. This client is plugin-internal and not exposed via any public API. A REST endpoint would need to wrap this client, creating a new API surface for a single consumer.
+
+As a step, persistence also benefits from the workflow's authentication context to resolve the space ID and authenticated user — both required for correct index targeting and audit logging. A REST endpoint would duplicate this resolution logic.
+
+The step also handles deduplication by querying the existing index for matching discoveries. Performing this check and the subsequent write atomically (within a single step execution) avoids race conditions that could arise if dedup-check and write were separate HTTP calls.
+
+### Inputs/Outputs Summary
+
+| Direction | Key Fields |
+|-----------|------------|
+| **Input** | `attack_discoveries`, `anonymized_alerts`, `api_config`, `connector_name`, `generation_uuid`, `alerts_context_count`, `replacements`, `enable_field_rendering`, `with_replacements` |
+| **Output** | `persisted_discoveries`, `duplicates_dropped_count` |
+
+---
+
+## Step 5: `attack-discovery.run`
+
+### Purpose
+
+Executes the full Attack Discovery pipeline (retrieval → generation → validation → persistence) as a single step. Supports both sync mode (returns discoveries inline) and async mode (returns `execution_uuid` immediately).
+
+### Consumer
+
+- **Agent Builder tools**: Need inline results from a single step invocation (sync mode).
+- **Simplified workflows**: Users who want full AD capability without composing four steps.
+- **Automation scripts**: External systems that invoke workflows and need a simple interface.
+
+### User Pattern
+
+```yaml
+steps:
+  - name: discover
+    type: attack-discovery.run
+    with:
+      connector_id: ${{ inputs.connector_id }}
+```
+
+Or with custom pre-retrieved alerts:
+
+```yaml
+steps:
+  - name: discover
+    type: attack-discovery.run
+    with:
+      connector_id: ${{ inputs.connector_id }}
+      alerts: ${{ steps.custom_retrieval.output.alerts }}
+      alert_retrieval_mode: provided
+```
+
+### Why Not a REST Endpoint
+
+The `_generate` endpoint is the REST equivalent for async mode, and it remains available. The `run` step exists because:
+
+1. **Sync mode cannot be a REST endpoint**: Blocking an HTTP connection for 2–10 minutes is not viable in production (proxy timeouts, browser disconnects). Within a workflow, the step can block as long as its `timeout` allows because the workflow engine manages the execution lifecycle.
+2. **Input simplification**: As a step, `run` resolves defaults (anonymization fields, connector name, alerts index pattern) from the execution context. A REST endpoint would need all of these as request parameters.
+3. **Output security**: The step deliberately excludes the replacements map from its output (see Architecture Decisions in the plugin README). A REST endpoint returning discoveries would need a separate mechanism to suppress sensitive data.
+4. **Composition**: A workflow can use `run` as one step among many. For example, a workflow could run Attack Discovery, then pass results to a `notify` step — all within a single workflow definition.
+
+### Inputs/Outputs Summary
+
+| Direction | Key Fields |
+|-----------|------------|
+| **Input** | `connector_id` (required), `alert_retrieval_mode` (enum: `custom_query`\|`disabled`\|`esql`\|`provided`, default `sync`), `mode` (enum: `async`\|`sync`, default `sync`), `alerts` (string[], optional pre-retrieved), `size`, `start`/`end`, `filter`, `esql_query`, `alert_retrieval_workflow_ids`, `validation_workflow_id`, `additional_context` |
+| **Output** | `attack_discoveries` (nullable array), `execution_uuid`, `alerts_context_count`, `discovery_count` |
+
+---
+
+## Common Definition Pattern
+
+Every step follows the same structural pattern:
+
+```
+common/step_types/<step_name>.ts        → StepTypeId, InputSchema, OutputSchema, CommonDefinition
+server/workflows/steps/<step_name>/     → getXxxStepDefinition() wrapping CommonDefinition with handler
+```
+
+The common definition is a `CommonStepDefinition<TInput, TOutput>` that includes:
+
+- `id`: Step type identifier (e.g., `attack-discovery.generate`)
+- `category`: `StepCategory.Elasticsearch | StepCategory.Ai | StepCategory.Kibana`
+- `label`: Human-readable name for the step catalog UI
+- `description`: One-sentence description
+- `inputSchema`: Zod schema defining the step's input contract
+- `outputSchema`: Zod schema defining the step's output contract
+
+This separation ensures that schema changes are reflected in both the step catalog and the server-side handler, and that input/output validation is enforced by the workflow engine before the handler executes.

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step.test.ts
@@ -1,0 +1,509 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import { loggerMock } from '@kbn/logging-mocks';
+import { coreMock } from '@kbn/core/server/mocks';
+import { actionsClientMock } from '@kbn/actions-plugin/server/actions_client/actions_client.mock';
+import type { AnonymizationFieldResponse } from '@kbn/elastic-assistant-common/impl/schemas';
+import { getDefaultAlertRetrievalStepDefinition } from './default_alert_retrieval_step';
+import { DefaultAlertRetrievalStepTypeId } from '../../../common/step_types/default_alert_retrieval_step';
+import { getAnonymizedAlerts } from '@kbn/discoveries/impl/attack_discovery/graphs';
+
+jest.mock('@kbn/discoveries/impl/attack_discovery/graphs', () => ({
+  ...jest.requireActual('@kbn/discoveries/impl/attack_discovery/graphs'),
+  getAnonymizedAlerts: jest.fn(),
+}));
+
+const mockGetAnonymizedAlerts = getAnonymizedAlerts as jest.Mock;
+
+describe('DefaultAlertRetrievalStepDefinition', () => {
+  const mockLogger: Logger = loggerMock.create();
+  const mockCoreStart = coreMock.createStart();
+  const mockActionsClient = actionsClientMock.create();
+  const mockEsClient = mockCoreStart.elasticsearch.client.asScoped({} as any).asCurrentUser;
+  const mockEventLogger = { logEvent: jest.fn() };
+  const mockGetEventLogger = jest.fn().mockResolvedValue(mockEventLogger);
+  const mockGetEventLogIndex = jest.fn().mockResolvedValue('.kibana-event-log-*');
+
+  const mockGetStartServices = jest.fn().mockResolvedValue({
+    coreStart: mockCoreStart,
+    pluginsStart: {
+      actions: {
+        getActionsClientWithRequest: jest.fn().mockResolvedValue(mockActionsClient),
+      },
+    },
+  });
+
+  const mockAnonymizationFields: AnonymizationFieldResponse[] = [
+    {
+      allowed: true,
+      anonymized: true,
+      field: 'host.name',
+      id: 'field-1',
+    },
+    {
+      allowed: true,
+      anonymized: true,
+      field: 'user.name',
+      id: 'field-2',
+    },
+  ];
+
+  const defaultProps = {
+    alerts_index_pattern: '.alerts-security.alerts-default',
+    anonymization_fields: mockAnonymizationFields,
+    api_config: {
+      action_type_id: '.gemini',
+      connector_id: 'test-connector',
+      model: 'test-model',
+    },
+    size: 10,
+  };
+
+  const mockContext = {
+    abortSignal: undefined,
+    contextManager: {
+      getContext: jest.fn().mockReturnValue({
+        execution: {
+          id: 'test-execution-id',
+        },
+        workflow: {
+          id: 'test-workflow-id',
+          spaceId: 'default',
+        },
+      }),
+      getFakeRequest: jest.fn().mockReturnValue({}),
+    },
+    input: defaultProps,
+    logger: mockLogger,
+  };
+
+  const mockAnonymizedAlertStrings = [
+    'timestamp,2025-01-01T00:00:00Z,host.name,HOST_001,user.name,USER_001',
+    'timestamp,2025-01-01T00:01:00Z,host.name,HOST_001,user.name,USER_002',
+  ];
+
+  const getOutputOrThrow = <T>(result: { output?: T }): T => {
+    if (!result.output) {
+      throw new Error('Expected result.output to be defined');
+    }
+
+    return result.output;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockActionsClient.get.mockResolvedValue({
+      id: 'test-connector',
+      name: 'Test Connector',
+    } as any);
+  });
+
+  const createStepDefinition = () =>
+    getDefaultAlertRetrievalStepDefinition({
+      getEventLogIndex: mockGetEventLogIndex,
+      getEventLogger: mockGetEventLogger,
+      getStartServices: mockGetStartServices,
+      logger: mockLogger,
+    });
+
+  describe('successful alert retrieval', () => {
+    it('returns anonymized alerts as strings', async () => {
+      mockGetAnonymizedAlerts.mockResolvedValue(mockAnonymizedAlertStrings);
+
+      const stepDefinition = createStepDefinition();
+
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.alerts).toEqual(mockAnonymizedAlertStrings);
+    });
+
+    it('returns alerts_context_count matching number of alerts', async () => {
+      mockGetAnonymizedAlerts.mockResolvedValue(mockAnonymizedAlertStrings);
+
+      const stepDefinition = createStepDefinition();
+
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.alerts_context_count).toBe(2);
+    });
+
+    it('returns anonymized_alerts in Document format', async () => {
+      mockGetAnonymizedAlerts.mockResolvedValue(mockAnonymizedAlertStrings);
+
+      const stepDefinition = createStepDefinition();
+
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.anonymized_alerts).toEqual([
+        {
+          metadata: {},
+          page_content: 'timestamp,2025-01-01T00:00:00Z,host.name,HOST_001,user.name,USER_001',
+        },
+        {
+          metadata: {},
+          page_content: 'timestamp,2025-01-01T00:01:00Z,host.name,HOST_001,user.name,USER_002',
+        },
+      ]);
+    });
+
+    it('returns api_config passed through from input', async () => {
+      mockGetAnonymizedAlerts.mockResolvedValue(mockAnonymizedAlertStrings);
+
+      const stepDefinition = createStepDefinition();
+
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.api_config).toEqual({
+        action_type_id: '.gemini',
+        connector_id: 'test-connector',
+        model: 'test-model',
+      });
+    });
+
+    it('returns connector_name from Actions client', async () => {
+      mockGetAnonymizedAlerts.mockResolvedValue(mockAnonymizedAlertStrings);
+
+      const stepDefinition = createStepDefinition();
+
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.connector_name).toBe('Test Connector');
+    });
+
+    it('returns empty replacements when none provided', async () => {
+      mockGetAnonymizedAlerts.mockResolvedValue(mockAnonymizedAlertStrings);
+
+      const stepDefinition = createStepDefinition();
+
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.replacements).toEqual({});
+    });
+
+    it('returns updated replacements from anonymization', async () => {
+      const inputReplacements = { server1: 'SERVER_001' };
+      const updatedReplacements = { server1: 'SERVER_001', server2: 'SERVER_002' };
+
+      mockGetAnonymizedAlerts.mockImplementation(({ onNewReplacements }) => {
+        onNewReplacements?.(updatedReplacements);
+        return Promise.resolve(mockAnonymizedAlertStrings);
+      });
+
+      const contextWithReplacements = {
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          replacements: inputReplacements,
+        },
+      };
+
+      const stepDefinition = createStepDefinition();
+
+      const result = await stepDefinition.handler(contextWithReplacements as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.replacements).toEqual(updatedReplacements);
+    });
+  });
+
+  describe('getAnonymizedAlerts invocation', () => {
+    it('invokes getAnonymizedAlerts with correct parameters', async () => {
+      mockGetAnonymizedAlerts.mockResolvedValue(mockAnonymizedAlertStrings);
+
+      const stepDefinition = createStepDefinition();
+
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockGetAnonymizedAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          alertsIndexPattern: '.alerts-security.alerts-default',
+          anonymizationFields: [
+            {
+              allowed: true,
+              anonymized: false,
+              field: '_id',
+              id: 'field-_id',
+            },
+            ...mockAnonymizationFields,
+          ],
+          end: undefined,
+          esClient: mockEsClient,
+          filter: undefined,
+          onNewReplacements: expect.any(Function),
+          replacements: {},
+          size: 10,
+          start: undefined,
+        })
+      );
+    });
+
+    it('passes optional start and end parameters', async () => {
+      mockGetAnonymizedAlerts.mockResolvedValue(mockAnonymizedAlertStrings);
+
+      const contextWithTimeRange = {
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          end: 'now',
+          start: 'now-24h',
+        },
+      };
+
+      const stepDefinition = createStepDefinition();
+
+      await stepDefinition.handler(contextWithTimeRange as any);
+
+      expect(mockGetAnonymizedAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          end: 'now',
+          start: 'now-24h',
+        })
+      );
+    });
+
+    it('passes optional filter parameter', async () => {
+      mockGetAnonymizedAlerts.mockResolvedValue(mockAnonymizedAlertStrings);
+
+      const filter = { term: { 'host.name': 'server1' } };
+      const contextWithFilter = {
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          filter,
+        },
+      };
+
+      const stepDefinition = createStepDefinition();
+
+      await stepDefinition.handler(contextWithFilter as any);
+
+      expect(mockGetAnonymizedAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter,
+        })
+      );
+    });
+
+    it('passes existing replacements to getAnonymizedAlerts', async () => {
+      mockGetAnonymizedAlerts.mockResolvedValue(mockAnonymizedAlertStrings);
+
+      const existingReplacements = { host1: 'HOST_001', user1: 'USER_001' };
+      const contextWithReplacements = {
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          replacements: existingReplacements,
+        },
+      };
+
+      const stepDefinition = createStepDefinition();
+
+      await stepDefinition.handler(contextWithReplacements as any);
+
+      expect(mockGetAnonymizedAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          replacements: existingReplacements,
+        })
+      );
+    });
+  });
+
+  describe('connector name retrieval', () => {
+    it('returns an error when connector lookup fails', async () => {
+      mockGetAnonymizedAlerts.mockResolvedValue(mockAnonymizedAlertStrings);
+      mockActionsClient.get.mockRejectedValue(new Error('Connector not found'));
+
+      const stepDefinition = createStepDefinition();
+
+      const result = await stepDefinition.handler(mockContext as any);
+
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error?.message).toContain('Connector not found');
+    });
+
+    it('retrieves connector by ID from api_config', async () => {
+      mockGetAnonymizedAlerts.mockResolvedValue(mockAnonymizedAlertStrings);
+
+      const stepDefinition = createStepDefinition();
+
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockActionsClient.get).toHaveBeenCalledWith({
+        id: 'test-connector',
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns error when getAnonymizedAlerts fails', async () => {
+      const alertError = new Error('Failed to retrieve alerts from Elasticsearch');
+      mockGetAnonymizedAlerts.mockRejectedValue(alertError);
+
+      const stepDefinition = createStepDefinition();
+
+      const result = await stepDefinition.handler(mockContext as any);
+
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error?.message).toBe('Failed to retrieve alerts from Elasticsearch');
+    });
+
+    it('logs error when alert retrieval fails', async () => {
+      const alertError = new Error('ES connection timeout');
+      mockGetAnonymizedAlerts.mockRejectedValue(alertError);
+
+      const stepDefinition = createStepDefinition();
+
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to retrieve alerts', alertError);
+    });
+
+    it('handles non-Error exceptions', async () => {
+      mockGetAnonymizedAlerts.mockRejectedValue('String error');
+
+      const stepDefinition = createStepDefinition();
+
+      const result = await stepDefinition.handler(mockContext as any);
+
+      expect(result.error?.message).toBe('Failed to retrieve alerts');
+    });
+  });
+
+  describe('empty results', () => {
+    it('handles zero alerts returned', async () => {
+      mockGetAnonymizedAlerts.mockResolvedValue([]);
+
+      const stepDefinition = createStepDefinition();
+
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.alerts).toEqual([]);
+      expect(output.alerts_context_count).toBe(0);
+      expect(output.anonymized_alerts).toEqual([]);
+    });
+  });
+
+  describe('logging', () => {
+    it('logs retrieval start with index pattern and size', async () => {
+      mockGetAnonymizedAlerts.mockResolvedValue(mockAnonymizedAlertStrings);
+
+      const stepDefinition = createStepDefinition();
+
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Retrieving alerts from .alerts-security.alerts-default with size 10'
+      );
+    });
+
+    it('logs retrieval completion with count', async () => {
+      mockGetAnonymizedAlerts.mockResolvedValue(mockAnonymizedAlertStrings);
+
+      const stepDefinition = createStepDefinition();
+
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockLogger.info).toHaveBeenCalledWith('Retrieved and anonymized 2 alerts');
+    });
+  });
+
+  describe('ES|QL path', () => {
+    const esqlQuery = 'FROM .alerts-security.alerts-default METADATA _id | LIMIT 10';
+
+    const esqlContext = {
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        esql_query: esqlQuery,
+      },
+    };
+
+    it('uses ES|QL query when esql_query is provided', async () => {
+      (mockEsClient.esql.query as jest.Mock).mockResolvedValue({
+        columns: [{ name: 'host.name' }],
+        values: [['server-1']],
+      });
+
+      const stepDefinition = createStepDefinition();
+
+      await stepDefinition.handler(esqlContext as any);
+
+      expect(mockEsClient.esql.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: esqlQuery,
+        })
+      );
+    });
+
+    it('does NOT call getAnonymizedAlerts when esql_query is provided', async () => {
+      (mockEsClient.esql.query as jest.Mock).mockResolvedValue({
+        columns: [{ name: 'host.name' }],
+        values: [['server-1']],
+      });
+
+      const stepDefinition = createStepDefinition();
+
+      await stepDefinition.handler(esqlContext as any);
+
+      expect(mockGetAnonymizedAlerts).not.toHaveBeenCalled();
+    });
+
+    it('does NOT pass a filter to the ES|QL query', async () => {
+      (mockEsClient.esql.query as jest.Mock).mockResolvedValue({
+        columns: [{ name: 'host.name' }],
+        values: [['server-1']],
+      });
+
+      const stepDefinition = createStepDefinition();
+
+      await stepDefinition.handler(esqlContext as any);
+
+      const callArgs = (mockEsClient.esql.query as jest.Mock).mock.calls[0][0] as Record<
+        string,
+        unknown
+      >;
+
+      expect(callArgs.filter).toBeUndefined();
+    });
+
+    it('returns alerts from ES|QL results', async () => {
+      (mockEsClient.esql.query as jest.Mock).mockResolvedValue({
+        columns: [{ name: 'host.name' }, { name: 'user.name' }],
+        values: [
+          ['server-1', 'admin'],
+          ['server-2', 'root'],
+        ],
+      });
+
+      const stepDefinition = createStepDefinition();
+
+      const result = await stepDefinition.handler(esqlContext as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.alerts.length).toBe(2);
+      expect(output.alerts_context_count).toBe(2);
+    });
+  });
+
+  describe('step metadata', () => {
+    it('has correct step type ID', () => {
+      const stepDefinition = createStepDefinition();
+
+      expect(stepDefinition.id).toBe(DefaultAlertRetrievalStepTypeId);
+      expect(DefaultAlertRetrievalStepTypeId).toBe('attack-discovery.defaultAlertRetrieval');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getDefaultAlertRetrievalStepDefinition } from './default_alert_retrieval_step/get_default_alert_retrieval_step_definition';

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step/get_default_alert_retrieval_step_definition.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step/get_default_alert_retrieval_step_definition.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import type { CoreStart, Logger } from '@kbn/core/server';
+import type { Replacements } from '@kbn/elastic-assistant-common';
+import { getAnonymizedAlerts } from '@kbn/discoveries/impl/attack_discovery/graphs';
+import { DefaultAlertRetrievalStepCommonDefinition } from '../../../../common/step_types/default_alert_retrieval_step';
+import type { DiscoveriesPluginStartDeps } from '../../../types';
+import { resolveConnectorDetails } from '../../helpers/resolve_connector_details';
+import { fetchAnonymizationFields } from './helpers/fetch_anonymization_fields';
+import {
+  ensureRequiredAnonymizationFields,
+  getAnonymizedAlertsFromEsql,
+} from './helpers/transform_alerts';
+
+/**
+ * Server-side implementation of the default alert retrieval step.
+ */
+export const getDefaultAlertRetrievalStepDefinition = ({
+  getEventLogIndex: _getEventLogIndex,
+  getEventLogger: _getEventLogger,
+  getStartServices,
+  logger: _logger,
+}: {
+  getEventLogIndex: () => Promise<string>;
+  getEventLogger: () => Promise<unknown>;
+  getStartServices: () => Promise<{
+    coreStart: CoreStart;
+    pluginsStart: DiscoveriesPluginStartDeps;
+  }>;
+  logger: Logger;
+}) =>
+  createServerStepDefinition({
+    ...DefaultAlertRetrievalStepCommonDefinition,
+    handler: async (context) => {
+      let spaceId: string | undefined;
+
+      try {
+        const workflowContext = context.contextManager.getContext();
+
+        spaceId = workflowContext.workflow.spaceId;
+
+        const {
+          alerts_index_pattern: alertsIndexPattern,
+          anonymization_fields: anonymizationFields,
+          api_config: apiConfig,
+          end,
+          esql_query: esqlQuery,
+          filter,
+          replacements: inputReplacements = {},
+          size,
+          start,
+        } = context.input;
+
+        context.logger.info(`Retrieving alerts from ${alertsIndexPattern} with size ${size}`);
+
+        const { coreStart, pluginsStart } = await getStartServices();
+        const request = context.contextManager.getFakeRequest();
+
+        const actionsClient = await pluginsStart.actions.getActionsClientWithRequest(request);
+        const esClient = coreStart.elasticsearch.client.asScoped(request).asCurrentUser;
+
+        const parsedApiConfig = apiConfig as {
+          action_type_id?: string;
+          connector_id: string;
+          model?: string;
+        };
+        const connectorId = parsedApiConfig.connector_id;
+
+        // Track replacements locally
+        let localReplacements: Replacements = { ...inputReplacements };
+        const onNewReplacements = (newReplacements: Replacements) => {
+          localReplacements = { ...localReplacements, ...newReplacements };
+        };
+
+        const resolvedAnonymizationFields = ensureRequiredAnonymizationFields(
+          anonymizationFields.length > 0
+            ? anonymizationFields
+            : await fetchAnonymizationFields({ esClient, spaceId })
+        );
+
+        // Retrieve and anonymize alerts
+        const anonymizedAlertStrings =
+          esqlQuery != null
+            ? await getAnonymizedAlertsFromEsql({
+                anonymizationFields: resolvedAnonymizationFields,
+                esClient,
+                esqlQuery,
+                onNewReplacements,
+                replacements: inputReplacements,
+              })
+            : await getAnonymizedAlerts({
+                alertsIndexPattern,
+                anonymizationFields: resolvedAnonymizationFields,
+                end: end ?? undefined,
+                esClient,
+                filter: filter ?? undefined,
+                onNewReplacements,
+                replacements: inputReplacements,
+                size,
+                start: start ?? undefined,
+              });
+
+        context.logger.info(`Retrieved and anonymized ${anonymizedAlertStrings.length} alerts`);
+
+        // Convert to Document format
+        const anonymizedAlerts: Array<{
+          id?: string;
+          metadata: Record<string, never>;
+          page_content: string;
+        }> = anonymizedAlertStrings.map((alertString) => ({
+          metadata: {} as Record<string, never>,
+          page_content: alertString,
+        }));
+
+        const { connectorName } = await resolveConnectorDetails({
+          actionsClient,
+          connectorId,
+          inference: pluginsStart.inference,
+          logger: _logger,
+          request,
+        });
+
+        return {
+          output: {
+            alerts: anonymizedAlertStrings,
+            alerts_context_count: anonymizedAlertStrings.length,
+            anonymized_alerts: anonymizedAlerts,
+            api_config: apiConfig,
+            connector_name: connectorName,
+            replacements: localReplacements,
+          },
+        };
+      } catch (error) {
+        context.logger.error('Failed to retrieve alerts', error);
+        return {
+          error: new Error(error instanceof Error ? error.message : 'Failed to retrieve alerts'),
+        };
+      }
+    },
+  });

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step/helpers/fetch_anonymization_fields/index.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step/helpers/fetch_anonymization_fields/index.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { fetchAnonymizationFields } from '.';
+
+const mockEsClient = {
+  search: jest.fn(),
+} as unknown as ElasticsearchClient;
+
+describe('fetchAnonymizationFields', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when the index contains fields', () => {
+    it('returns mapped anonymization fields', async () => {
+      (mockEsClient.search as jest.Mock).mockResolvedValue({
+        hits: {
+          hits: [
+            {
+              _id: 'field-1',
+              _source: {
+                '@timestamp': '2024-01-01T00:00:00Z',
+                allowed: true,
+                anonymized: false,
+                created_at: '2024-01-01',
+                created_by: 'elastic',
+                field: 'host.name',
+                namespace: 'default',
+                updated_at: '2024-01-02',
+                updated_by: 'elastic',
+              },
+            },
+          ],
+        },
+      });
+
+      const result = await fetchAnonymizationFields({ esClient: mockEsClient, spaceId: 'default' });
+
+      expect(result).toEqual([
+        {
+          allowed: true,
+          anonymized: false,
+          createdAt: '2024-01-01',
+          createdBy: 'elastic',
+          field: 'host.name',
+          id: 'field-1',
+          namespace: 'default',
+          timestamp: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-02',
+          updatedBy: 'elastic',
+        },
+      ]);
+    });
+
+    it('queries the correct space-scoped index', async () => {
+      (mockEsClient.search as jest.Mock).mockResolvedValue({ hits: { hits: [] } });
+
+      await fetchAnonymizationFields({ esClient: mockEsClient, spaceId: 'my-space' });
+
+      expect(mockEsClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: '.kibana-elastic-ai-assistant-anonymization-fields-my-space',
+        })
+      );
+    });
+
+    it('filters out hits without _source', async () => {
+      (mockEsClient.search as jest.Mock).mockResolvedValue({
+        hits: {
+          hits: [
+            { _id: 'no-source', _source: undefined },
+            {
+              _id: 'with-source',
+              _source: { allowed: true, anonymized: false, field: 'user.name' },
+            },
+          ],
+        },
+      });
+
+      const result = await fetchAnonymizationFields({ esClient: mockEsClient, spaceId: 'default' });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('with-source');
+    });
+
+    it('uses empty string for id when _id is undefined', async () => {
+      (mockEsClient.search as jest.Mock).mockResolvedValue({
+        hits: {
+          hits: [
+            {
+              _id: undefined,
+              _source: { allowed: true, anonymized: false, field: 'host.ip' },
+            },
+          ],
+        },
+      });
+
+      const result = await fetchAnonymizationFields({ esClient: mockEsClient, spaceId: 'default' });
+
+      expect(result[0].id).toBe('');
+    });
+  });
+
+  describe('when the index does not exist or query fails', () => {
+    it('returns an empty array on error', async () => {
+      (mockEsClient.search as jest.Mock).mockRejectedValue(new Error('index_not_found_exception'));
+
+      const result = await fetchAnonymizationFields({ esClient: mockEsClient, spaceId: 'default' });
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns an empty array when hits are empty', async () => {
+      (mockEsClient.search as jest.Mock).mockResolvedValue({ hits: { hits: [] } });
+
+      const result = await fetchAnonymizationFields({ esClient: mockEsClient, spaceId: 'default' });
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step/helpers/fetch_anonymization_fields/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step/helpers/fetch_anonymization_fields/index.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { AnonymizationFieldResponse } from '@kbn/elastic-assistant-common/impl/schemas';
+
+/**
+ * Fetches anonymization fields from the AI Assistant index for the given space.
+ * Returns an empty array when the index does not exist or the query fails.
+ */
+export const fetchAnonymizationFields = async ({
+  esClient,
+  spaceId,
+}: {
+  esClient: ElasticsearchClient;
+  spaceId: string;
+}): Promise<AnonymizationFieldResponse[]> => {
+  const index = `.kibana-elastic-ai-assistant-anonymization-fields-${spaceId}`;
+
+  try {
+    const response = await esClient.search({
+      index,
+      query: { match_all: {} },
+      size: 1000,
+    });
+
+    return response.hits.hits
+      .filter((hit) => hit._source !== undefined)
+      .map((hit) => {
+        const source = hit._source as Record<string, unknown>;
+        return {
+          allowed: source.allowed as boolean,
+          anonymized: source.anonymized as boolean,
+          createdAt: source.created_at as string | undefined,
+          createdBy: source.created_by as string | undefined,
+          field: source.field as string,
+          id: hit._id ?? '',
+          namespace: source.namespace as string | undefined,
+          timestamp: source['@timestamp'] as string | undefined,
+          updatedAt: source.updated_at as string | undefined,
+          updatedBy: source.updated_by as string | undefined,
+        };
+      });
+  } catch {
+    // If the index doesn't exist or there's an error, return empty array.
+    return [];
+  }
+};

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step/helpers/transform_alerts/index.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step/helpers/transform_alerts/index.test.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { AnonymizationFieldResponse } from '@kbn/elastic-assistant-common/impl/schemas';
+import {
+  convertEsqlRowToRawData,
+  ensureRequiredAnonymizationFields,
+  getAnonymizedAlertsFromEsql,
+} from '.';
+
+jest.mock('@kbn/elastic-assistant-common', () => ({
+  getAnonymizedValue: jest.fn((value: unknown) => String(value)),
+  getRawDataOrDefault: jest.fn((data: unknown) => data),
+  transformRawData: jest.fn(({ rawData }: { rawData: Record<string, unknown[]> }) =>
+    Object.entries(rawData)
+      .map(([k, v]) => `${k},${v[0] ?? ''}`)
+      .join(',')
+  ),
+}));
+
+describe('convertEsqlRowToRawData', () => {
+  it('maps column names to arrays of values', () => {
+    const result = convertEsqlRowToRawData({
+      columns: [{ name: 'host.name' }, { name: 'user.name' }],
+      row: ['server-1', 'admin'],
+    });
+
+    expect(result).toEqual({
+      'host.name': ['server-1'],
+      'user.name': ['admin'],
+    });
+  });
+
+  it('uses column_N fallback when name is undefined', () => {
+    const result = convertEsqlRowToRawData({
+      columns: [{ name: undefined }],
+      row: ['value'],
+    });
+
+    expect(result).toEqual({ column_0: ['value'] });
+  });
+
+  it('stores empty array for null values', () => {
+    const result = convertEsqlRowToRawData({
+      columns: [{ name: 'host.name' }],
+      row: [null],
+    });
+
+    expect(result).toEqual({ 'host.name': [] });
+  });
+
+  it('stores empty array for undefined values', () => {
+    const result = convertEsqlRowToRawData({
+      columns: [{ name: 'host.name' }],
+      row: [undefined],
+    });
+
+    expect(result).toEqual({ 'host.name': [] });
+  });
+
+  it('handles empty columns and row', () => {
+    const result = convertEsqlRowToRawData({ columns: [], row: [] });
+
+    expect(result).toEqual({});
+  });
+});
+
+describe('ensureRequiredAnonymizationFields', () => {
+  it('returns fields unchanged when _id is already present', () => {
+    const fields: AnonymizationFieldResponse[] = [
+      { allowed: true, anonymized: false, field: '_id', id: 'existing-id' },
+      { allowed: true, anonymized: true, field: 'host.name', id: 'field-2' },
+    ];
+
+    const result = ensureRequiredAnonymizationFields(fields);
+
+    expect(result).toBe(fields);
+  });
+
+  it('prepends _id field when missing', () => {
+    const fields: AnonymizationFieldResponse[] = [
+      { allowed: true, anonymized: true, field: 'host.name', id: 'field-1' },
+    ];
+
+    const result = ensureRequiredAnonymizationFields(fields);
+
+    expect(result[0]).toEqual({
+      allowed: true,
+      anonymized: false,
+      field: '_id',
+      id: 'field-_id',
+    });
+  });
+
+  it('preserves existing fields when prepending _id', () => {
+    const fields: AnonymizationFieldResponse[] = [
+      { allowed: true, anonymized: true, field: 'host.name', id: 'field-1' },
+    ];
+
+    const result = ensureRequiredAnonymizationFields(fields);
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toEqual(fields[0]);
+  });
+
+  it('returns empty array unchanged when no fields provided', () => {
+    const result = ensureRequiredAnonymizationFields([]);
+
+    expect(result[0]).toEqual({
+      allowed: true,
+      anonymized: false,
+      field: '_id',
+      id: 'field-_id',
+    });
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('getAnonymizedAlertsFromEsql', () => {
+  const mockEsClient = {
+    esql: { query: jest.fn() },
+  } as unknown as ElasticsearchClient;
+
+  const anonymizationFields: AnonymizationFieldResponse[] = [
+    { allowed: true, anonymized: false, field: 'host.name', id: 'f1' },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls esql.query with the provided query', async () => {
+    (mockEsClient.esql.query as jest.Mock).mockResolvedValue({
+      columns: [],
+      values: [],
+    });
+
+    await getAnonymizedAlertsFromEsql({
+      anonymizationFields,
+      esClient: mockEsClient,
+      esqlQuery: 'FROM .alerts | LIMIT 10',
+    });
+
+    expect(mockEsClient.esql.query).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'FROM .alerts | LIMIT 10' })
+    );
+  });
+
+  it('returns one string per row', async () => {
+    (mockEsClient.esql.query as jest.Mock).mockResolvedValue({
+      columns: [{ name: 'host.name' }],
+      values: [['server-1'], ['server-2']],
+    });
+
+    const result = await getAnonymizedAlertsFromEsql({
+      anonymizationFields,
+      esClient: mockEsClient,
+      esqlQuery: 'FROM .alerts | LIMIT 10',
+    });
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns empty array when there are no rows', async () => {
+    (mockEsClient.esql.query as jest.Mock).mockResolvedValue({
+      columns: [{ name: 'host.name' }],
+      values: [],
+    });
+
+    const result = await getAnonymizedAlertsFromEsql({
+      anonymizationFields,
+      esClient: mockEsClient,
+      esqlQuery: 'FROM .alerts | LIMIT 10',
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('calls onNewReplacements when replacements are updated', async () => {
+    const { transformRawData: mockTransformRawData } = jest.requireMock(
+      '@kbn/elastic-assistant-common'
+    );
+    mockTransformRawData.mockImplementation(
+      ({ onNewReplacements: cb }: { onNewReplacements: (r: Record<string, string>) => void }) => {
+        cb({ 'server-1': 'SERVER_001' });
+        return 'anonymized';
+      }
+    );
+
+    (mockEsClient.esql.query as jest.Mock).mockResolvedValue({
+      columns: [{ name: 'host.name' }],
+      values: [['server-1']],
+    });
+
+    const onNewReplacements = jest.fn();
+
+    await getAnonymizedAlertsFromEsql({
+      anonymizationFields,
+      esClient: mockEsClient,
+      esqlQuery: 'FROM .alerts',
+      onNewReplacements,
+    });
+
+    expect(onNewReplacements).toHaveBeenCalledWith({ 'server-1': 'SERVER_001' });
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step/helpers/transform_alerts/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step/helpers/transform_alerts/index.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  getAnonymizedValue,
+  getRawDataOrDefault,
+  transformRawData,
+} from '@kbn/elastic-assistant-common';
+import type { Replacements } from '@kbn/elastic-assistant-common';
+import type { AnonymizationFieldResponse } from '@kbn/elastic-assistant-common/impl/schemas';
+import type { ElasticsearchClient } from '@kbn/core/server';
+
+/**
+ * Converts an ES|QL result row (array of values) to the raw data format
+ * expected by transformRawData (Record<string, unknown[]>).
+ */
+export const convertEsqlRowToRawData = ({
+  columns,
+  row,
+}: {
+  columns: Array<{ name?: string }>;
+  row: unknown[];
+}): Record<string, unknown[]> => {
+  const rawData: Record<string, unknown[]> = {};
+  for (let i = 0; i < columns.length; i++) {
+    const columnName = columns[i].name ?? `column_${i}`;
+    const value = row[i];
+    rawData[columnName] = value != null ? [value] : [];
+  }
+  return rawData;
+};
+
+/**
+ * Retrieves and anonymizes alerts using an ES|QL query.
+ */
+export const getAnonymizedAlertsFromEsql = async ({
+  anonymizationFields,
+  esClient,
+  esqlQuery,
+  onNewReplacements,
+  replacements,
+}: {
+  anonymizationFields: AnonymizationFieldResponse[];
+  esClient: ElasticsearchClient;
+  esqlQuery: string;
+  onNewReplacements?: (replacements: Replacements) => void;
+  replacements?: Replacements;
+}): Promise<string[]> => {
+  const response = await esClient.esql.query({
+    allow_partial_results: true,
+    drop_null_columns: true,
+    query: esqlQuery,
+  });
+
+  const { columns, values } = response;
+
+  let localReplacements = { ...(replacements ?? {}) };
+  const localOnNewReplacements = (newReplacements: Replacements) => {
+    localReplacements = { ...localReplacements, ...newReplacements };
+    onNewReplacements?.(localReplacements);
+  };
+
+  return values.map((row) =>
+    transformRawData({
+      anonymizationFields,
+      currentReplacements: localReplacements,
+      getAnonymizedValue,
+      onNewReplacements: localOnNewReplacements,
+      rawData: getRawDataOrDefault(convertEsqlRowToRawData({ columns, row })),
+    })
+  );
+};
+
+/**
+ * Ensure required fields exist in anonymization configuration.
+ *
+ * The Attack Discovery pipeline relies on the alert `_id` being present in the
+ * anonymized alert strings so downstream steps (generation + validation) can
+ * reference *real* alert IDs for hallucination detection and persistence.
+ */
+export const ensureRequiredAnonymizationFields = (
+  fields: AnonymizationFieldResponse[]
+): AnonymizationFieldResponse[] => {
+  const hasIdField = fields.some((field) => field.field === '_id');
+  if (hasIdField) {
+    return fields;
+  }
+
+  return [
+    {
+      allowed: true,
+      anonymized: false,
+      field: '_id',
+      id: 'field-_id',
+    },
+    ...fields,
+  ];
+};

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_alert_retrieval_step/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getDefaultAlertRetrievalStepDefinition } from './get_default_alert_retrieval_step_definition';

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step.test.ts
@@ -1,0 +1,380 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import type { StepHandlerContext } from '@kbn/workflows-extensions/server';
+import { getDefaultValidationStepDefinition } from './default_validation_step';
+import { getSpaceId } from '@kbn/discoveries/impl/lib/helpers/get_space_id';
+import { filterHallucinatedAlerts } from '@kbn/discoveries/impl/attack_discovery/hallucination_detection';
+
+jest.mock('@kbn/discoveries/impl/lib/helpers/get_space_id', () => ({
+  getSpaceId: jest.fn(),
+}));
+
+jest.mock('@kbn/discoveries/impl/attack_discovery/hallucination_detection', () => ({
+  ...jest.requireActual('@kbn/discoveries/impl/attack_discovery/hallucination_detection'),
+  filterHallucinatedAlerts: jest.fn(),
+}));
+
+const mockUuid = 'mock-generated-uuid';
+jest.mock('uuid', () => ({
+  v4: () => mockUuid,
+}));
+
+describe('getDefaultValidationStepDefinition', () => {
+  let mockLogger: ReturnType<typeof loggerMock.create>;
+  let mockAuthenticate: jest.Mock;
+  let mockAsScoped: jest.Mock;
+  let mockGetStartServices: jest.Mock;
+  let stepDefinition: ReturnType<typeof getDefaultValidationStepDefinition>;
+
+  const mockRequest = { headers: { authorization: 'ApiKey abc' } };
+
+  const defaultInput = {
+    alerts_context_count: 1,
+    anonymized_alerts: [{ metadata: {}, page_content: 'a' }],
+    api_config: { action_type_id: '.gen', connector_id: 'connector-1' },
+    attack_discoveries: [
+      {
+        alert_ids: ['a1'],
+        details_markdown: 'details',
+        entity_summary_markdown: 'entity',
+        mitre_attack_tactics: ['Execution'],
+        summary_markdown: 'summary',
+        timestamp: '2025-12-15T18:39:20.762Z',
+        title: 'title',
+      },
+    ],
+    connector_name: 'Connector 1',
+    generation_uuid: 'generation-1',
+  };
+
+  const createContext = (input = defaultInput): StepHandlerContext<unknown> =>
+    ({
+      contextManager: {
+        getContext: () => ({
+          execution: {
+            id: 'test-workflow-run-id',
+          },
+          workflow: {
+            id: 'test-workflow-id',
+            spaceId: 'default',
+          },
+        }),
+        getFakeRequest: () => mockRequest,
+      },
+      input,
+      logger: { error: jest.fn(), info: jest.fn() },
+    } as unknown as StepHandlerContext<unknown>);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockLogger = loggerMock.create();
+    mockAuthenticate = jest.fn().mockResolvedValue({ profile_uid: 'p1', username: 'u1' });
+    mockAsScoped = jest.fn().mockReturnValue({
+      asCurrentUser: {
+        security: { authenticate: mockAuthenticate },
+        search: jest.fn(),
+      },
+    });
+    mockGetStartServices = jest.fn().mockResolvedValue({
+      coreStart: {
+        elasticsearch: { client: { asScoped: mockAsScoped } },
+      } as unknown,
+      pluginsStart: {
+        actions: {
+          getActionsClientWithRequest: jest.fn().mockResolvedValue({
+            get: jest.fn().mockResolvedValue({
+              actionTypeId: '.gen',
+              name: 'Connector 1',
+            }),
+          }),
+        },
+        spaces: { spacesService: null },
+      } as unknown,
+    });
+
+    stepDefinition = getDefaultValidationStepDefinition({
+      getStartServices: mockGetStartServices,
+      logger: mockLogger,
+    });
+
+    (getSpaceId as jest.Mock).mockReturnValue('default');
+
+    (filterHallucinatedAlerts as jest.Mock).mockImplementation(({ attackDiscoveries }) =>
+      Promise.resolve(attackDiscoveries)
+    );
+  });
+
+  describe('successful validation', () => {
+    it('returns output with validated_discoveries', async () => {
+      const context = createContext();
+
+      const result = await stepDefinition.handler(context);
+
+      expect(result.output?.validated_discoveries).toHaveLength(1);
+    });
+
+    it('returns output without error property', async () => {
+      const context = createContext();
+
+      const result = await stepDefinition.handler(context);
+
+      expect(result.error).toBeUndefined();
+    });
+
+    it('returns transformed discoveries with connector metadata', async () => {
+      const context = createContext();
+
+      const result = await stepDefinition.handler(context);
+
+      const discovery = result.output?.validated_discoveries[0] as Record<string, unknown>;
+      expect(discovery.connector_id).toBe('connector-1');
+      expect(discovery.connector_name).toBe('Connector 1');
+      expect(discovery.generation_uuid).toBe('generation-1');
+    });
+
+    it('returns filtered_count of 0 when all discoveries pass', async () => {
+      const context = createContext();
+
+      const result = await stepDefinition.handler(context);
+
+      expect(result.output?.filtered_count).toBe(0);
+    });
+  });
+
+  describe('authentication', () => {
+    it('calls authenticate on elasticsearch client', async () => {
+      const context = createContext();
+
+      await stepDefinition.handler(context);
+
+      expect(mockAuthenticate).toHaveBeenCalled();
+    });
+
+    it('returns error when authentication fails', async () => {
+      mockAuthenticate.mockRejectedValue(new Error('auth failed'));
+
+      const context = createContext();
+
+      const result = await stepDefinition.handler(context);
+
+      expect(result.error).toBeDefined();
+    });
+
+    it('returns error message when authentication fails', async () => {
+      mockAuthenticate.mockRejectedValue(new Error('auth failed'));
+
+      const context = createContext();
+
+      const result = await stepDefinition.handler(context);
+
+      expect(result.error?.message).toBe('auth failed');
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns generic error message when non-Error is thrown', async () => {
+      mockAuthenticate.mockRejectedValue('boom');
+
+      const context = createContext();
+
+      const result = await stepDefinition.handler(context);
+
+      expect(result.error?.message).toBe('Failed to validate discoveries');
+    });
+
+    it('returns error when non-Error is thrown', async () => {
+      mockAuthenticate.mockRejectedValue('boom');
+
+      const context = createContext();
+
+      const result = await stepDefinition.handler(context);
+
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  describe('space resolution', () => {
+    it('calls getSpaceId with spaces service', async () => {
+      const context = createContext();
+
+      await stepDefinition.handler(context);
+
+      expect(getSpaceId).toHaveBeenCalledWith({
+        request: mockRequest,
+        spaces: null,
+      });
+    });
+  });
+
+  describe('empty attack discoveries', () => {
+    it('returns empty array when attack_discoveries is null', async () => {
+      const inputWithNullDiscoveries = {
+        ...defaultInput,
+        attack_discoveries: null,
+      };
+      const context = createContext(inputWithNullDiscoveries as never);
+
+      const result = await stepDefinition.handler(context);
+
+      expect(result.output?.validated_discoveries).toEqual([]);
+    });
+
+    it('returns empty array when attack_discoveries is empty', async () => {
+      const inputWithEmptyDiscoveries = {
+        ...defaultInput,
+        attack_discoveries: [],
+      };
+      const context = createContext(inputWithEmptyDiscoveries);
+
+      const result = await stepDefinition.handler(context);
+
+      expect(result.output?.validated_discoveries).toEqual([]);
+    });
+
+    it('returns filter_reason no_discoveries when empty', async () => {
+      const inputWithEmptyDiscoveries = {
+        ...defaultInput,
+        attack_discoveries: [],
+      };
+      const context = createContext(inputWithEmptyDiscoveries);
+
+      const result = await stepDefinition.handler(context);
+
+      expect(result.output?.filter_reason).toBe('no_discoveries');
+      expect(result.output?.filtered_count).toBe(0);
+    });
+
+    it('logs info message when no discoveries to validate', async () => {
+      const inputWithEmptyDiscoveries = {
+        ...defaultInput,
+        attack_discoveries: [],
+      };
+      const context = createContext(inputWithEmptyDiscoveries);
+
+      await stepDefinition.handler(context);
+
+      expect(context.logger.info).toHaveBeenCalledWith('No attack discoveries to validate');
+    });
+  });
+
+  describe('logging', () => {
+    it('logs debug message with parsed input', async () => {
+      const context = createContext();
+
+      await stepDefinition.handler(context);
+
+      expect(mockLogger.debug).toHaveBeenCalled();
+    });
+
+    it('logs info message with validation count', async () => {
+      const context = createContext();
+
+      await stepDefinition.handler(context);
+
+      expect(context.logger.info).toHaveBeenCalledWith(
+        'Validating 1 attack discoveries (generation: generation-1)'
+      );
+    });
+  });
+
+  describe('error logging', () => {
+    it('logs debug message when error occurs', async () => {
+      mockAuthenticate.mockRejectedValue(new Error('test error'));
+
+      const context = createContext();
+
+      await stepDefinition.handler(context);
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('logs error to context logger', async () => {
+      mockAuthenticate.mockRejectedValue(new Error('test error'));
+
+      const context = createContext();
+
+      await stepDefinition.handler(context);
+
+      expect(context.logger.error).toHaveBeenCalledWith(
+        'Failed to validate discoveries',
+        expect.any(Error)
+      );
+    });
+  });
+
+  describe('hallucination detection', () => {
+    it('calls filterHallucinatedAlerts with correct parameters', async () => {
+      const context = createContext();
+
+      await stepDefinition.handler(context);
+
+      expect(filterHallucinatedAlerts).toHaveBeenCalledWith({
+        alertsIndexPattern: '.alerts-security.alerts-*',
+        attackDiscoveries: defaultInput.attack_discoveries,
+        esClient: expect.anything(),
+        logger: expect.objectContaining({
+          debug: expect.any(Function),
+          error: expect.any(Function),
+          info: expect.any(Function),
+          warn: expect.any(Function),
+        }),
+      });
+    });
+
+    it('uses custom alerts_index_pattern when provided', async () => {
+      const inputWithCustomPattern = {
+        ...defaultInput,
+        alerts_index_pattern: '.custom-alerts-*',
+      };
+      const context = createContext(inputWithCustomPattern);
+
+      await stepDefinition.handler(context);
+
+      expect(filterHallucinatedAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          alertsIndexPattern: '.custom-alerts-*',
+        })
+      );
+    });
+
+    it('returns empty array when all discoveries are filtered out', async () => {
+      (filterHallucinatedAlerts as jest.Mock).mockResolvedValue([]);
+
+      const context = createContext();
+
+      const result = await stepDefinition.handler(context);
+
+      expect(result.output?.validated_discoveries).toEqual([]);
+    });
+
+    it('returns hallucinated_alert_ids filter_reason when all filtered', async () => {
+      (filterHallucinatedAlerts as jest.Mock).mockResolvedValue([]);
+
+      const context = createContext();
+
+      const result = await stepDefinition.handler(context);
+
+      expect(result.output?.filter_reason).toBe('hallucinated_alert_ids');
+      expect(result.output?.filtered_count).toBe(1);
+    });
+
+    it('logs info message when all discoveries are filtered out', async () => {
+      (filterHallucinatedAlerts as jest.Mock).mockResolvedValue([]);
+
+      const context = createContext();
+
+      await stepDefinition.handler(context);
+
+      expect(context.logger.info).toHaveBeenCalledWith(
+        'All attack discoveries were filtered out due to hallucinated alert IDs'
+      );
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getDefaultValidationStepDefinition } from './default_validation_step/get_default_validation_step_definition';

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/get_default_validation_step_definition.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/get_default_validation_step_definition.test.ts
@@ -1,0 +1,411 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+
+import { getDefaultValidationStepDefinition } from './get_default_validation_step_definition';
+import { resolveConnectorDetails } from '../../helpers/resolve_connector_details';
+import { authenticateAndGetSpace } from './helpers/authenticate_and_get_space';
+import {
+  filterAndValidateDiscoveries,
+  type FilterResult,
+} from './helpers/filter_and_validate_discoveries';
+import { transformDiscoveriesToOutputFormat } from './helpers/transform_discoveries_to_output_format';
+
+jest.mock('../../helpers/resolve_connector_details', () => ({
+  resolveConnectorDetails: jest.fn(),
+}));
+
+jest.mock('./helpers/authenticate_and_get_space', () => ({
+  authenticateAndGetSpace: jest.fn(),
+}));
+
+jest.mock('./helpers/filter_and_validate_discoveries', () => ({
+  filterAndValidateDiscoveries: jest.fn(),
+}));
+
+jest.mock('./helpers/transform_discoveries_to_output_format', () => ({
+  transformDiscoveriesToOutputFormat: jest.fn(),
+}));
+
+const mockResolveConnectorDetails = resolveConnectorDetails as jest.MockedFunction<
+  typeof resolveConnectorDetails
+>;
+const mockAuthenticateAndGetSpace = authenticateAndGetSpace as jest.MockedFunction<
+  typeof authenticateAndGetSpace
+>;
+const mockFilterAndValidateDiscoveries = filterAndValidateDiscoveries as jest.MockedFunction<
+  typeof filterAndValidateDiscoveries
+>;
+const mockTransformDiscoveriesToOutputFormat =
+  transformDiscoveriesToOutputFormat as jest.MockedFunction<
+    typeof transformDiscoveriesToOutputFormat
+  >;
+
+describe('getDefaultValidationStepDefinition', () => {
+  const mockLogger = {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  } as unknown as Logger;
+
+  const mockActionsClient = { get: jest.fn() };
+
+  const mockGetStartServices = jest.fn().mockResolvedValue({
+    coreStart: {},
+    pluginsStart: {
+      actions: {
+        getActionsClientWithRequest: jest.fn().mockResolvedValue(mockActionsClient),
+      },
+    },
+  });
+
+  const mockEsClient = {};
+
+  const mockContext = {
+    contextManager: {
+      getContext: jest.fn().mockReturnValue({
+        execution: { id: 'workflow-run-1' },
+        workflow: { id: 'workflow-1' },
+      }),
+      getFakeRequest: jest.fn().mockReturnValue({
+        headers: {},
+      }),
+    },
+    input: {
+      alerts_context_count: 10,
+      alerts_index_pattern: '.alerts-security.alerts-default',
+      anonymized_alerts: [],
+      api_config: { connector_id: 'connector-1' },
+      attack_discoveries: [
+        {
+          alert_ids: ['alert-1'],
+          details_markdown: 'Details',
+          entity_summary_markdown: 'Entity',
+          mitre_attack_tactics: ['Initial Access'],
+          summary_markdown: 'Summary',
+          title: 'Test Discovery',
+        },
+      ],
+      connector_name: 'Test Connector',
+      enable_field_rendering: true,
+      generation_uuid: 'generation-1',
+      replacements: {},
+      with_replacements: false,
+    },
+    logger: {
+      error: jest.fn(),
+      info: jest.fn(),
+    },
+  };
+
+  const getOutputOrThrow = <T>(result: { output?: T }): T => {
+    if (!result.output) {
+      throw new Error('Expected result.output to be defined');
+    }
+
+    return result.output;
+  };
+
+  const transformedDiscoveries = [
+    {
+      alert_ids: ['alert-1'],
+      connector_id: 'connector-1',
+      connector_name: 'Test Connector',
+      details_markdown: 'Details',
+      entity_summary_markdown: 'Entity',
+      generation_uuid: 'generation-1',
+      id: 'generated-id',
+      mitre_attack_tactics: ['Initial Access'],
+      summary_markdown: 'Summary',
+      timestamp: '2025-01-01T00:00:00Z',
+      title: 'Test Discovery',
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockResolveConnectorDetails.mockResolvedValue({
+      actionTypeId: '.gen-ai',
+      connectorName: 'Test Connector',
+    });
+
+    mockAuthenticateAndGetSpace.mockResolvedValue({
+      authenticationInfo: {},
+      authenticatedUser: { profile_uid: 'profile-1', username: 'test-user' },
+      esClient: mockEsClient,
+      spaceId: 'default',
+    } as unknown as Awaited<ReturnType<typeof authenticateAndGetSpace>>);
+
+    mockTransformDiscoveriesToOutputFormat.mockReturnValue(transformedDiscoveries);
+  });
+
+  describe('when validation succeeds with discoveries', () => {
+    beforeEach(() => {
+      mockFilterAndValidateDiscoveries.mockResolvedValue({
+        filteredCount: 0,
+        shouldValidate: true,
+        validDiscoveries: mockContext.input.attack_discoveries,
+      } as FilterResult<(typeof mockContext.input.attack_discoveries)[number]>);
+    });
+
+    it('returns validated discoveries from transformDiscoveriesToOutputFormat', async () => {
+      const stepDefinition = getDefaultValidationStepDefinition({
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      const result = await stepDefinition.handler(mockContext as never);
+
+      const output = getOutputOrThrow(result);
+
+      expect(output.validated_discoveries).toEqual(transformedDiscoveries);
+    });
+
+    it('returns filtered_count of 0 when no discoveries were filtered', async () => {
+      const stepDefinition = getDefaultValidationStepDefinition({
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      const result = await stepDefinition.handler(mockContext as never);
+
+      const output = getOutputOrThrow(result);
+
+      expect(output.filtered_count).toBe(0);
+    });
+
+    it('does not include filter_reason when no discoveries were filtered', async () => {
+      const stepDefinition = getDefaultValidationStepDefinition({
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      const result = await stepDefinition.handler(mockContext as never);
+
+      const output = getOutputOrThrow(result);
+
+      expect(output).not.toHaveProperty('filter_reason');
+    });
+
+    it('calls transformDiscoveriesToOutputFormat with the correct arguments', async () => {
+      const stepDefinition = getDefaultValidationStepDefinition({
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      await stepDefinition.handler(mockContext as never);
+
+      expect(mockTransformDiscoveriesToOutputFormat).toHaveBeenCalledWith({
+        attackDiscoveries: mockContext.input.attack_discoveries,
+        connectorId: 'connector-1',
+        connectorName: 'Test Connector',
+        generationUuid: 'generation-1',
+        replacements: {},
+      });
+    });
+  });
+
+  describe('when some discoveries are filtered by hallucination detection', () => {
+    beforeEach(() => {
+      mockFilterAndValidateDiscoveries.mockResolvedValue({
+        filteredCount: 2,
+        filterReason: 'hallucinated_alert_ids',
+        shouldValidate: true,
+        validDiscoveries: mockContext.input.attack_discoveries,
+      } as FilterResult<(typeof mockContext.input.attack_discoveries)[number]>);
+    });
+
+    it('returns the filtered_count from filterAndValidateDiscoveries', async () => {
+      const stepDefinition = getDefaultValidationStepDefinition({
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      const result = await stepDefinition.handler(mockContext as never);
+
+      const output = getOutputOrThrow(result);
+
+      expect(output.filtered_count).toBe(2);
+    });
+
+    it('returns the filter_reason from filterAndValidateDiscoveries', async () => {
+      const stepDefinition = getDefaultValidationStepDefinition({
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      const result = await stepDefinition.handler(mockContext as never);
+
+      const output = getOutputOrThrow(result);
+
+      expect(output.filter_reason).toBe('hallucinated_alert_ids');
+    });
+  });
+
+  describe('when no discoveries pass filtering', () => {
+    beforeEach(() => {
+      mockFilterAndValidateDiscoveries.mockResolvedValue({
+        filteredCount: 1,
+        filterReason: 'hallucinated_alert_ids',
+        shouldValidate: false,
+        validDiscoveries: [],
+      } as FilterResult<(typeof mockContext.input.attack_discoveries)[number]>);
+    });
+
+    it('returns empty validated_discoveries array', async () => {
+      const stepDefinition = getDefaultValidationStepDefinition({
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      const result = await stepDefinition.handler(mockContext as never);
+
+      const output = getOutputOrThrow(result);
+
+      expect(output.validated_discoveries).toEqual([]);
+    });
+
+    it('returns the filtered_count and filter_reason', async () => {
+      const stepDefinition = getDefaultValidationStepDefinition({
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      const result = await stepDefinition.handler(mockContext as never);
+
+      const output = getOutputOrThrow(result);
+
+      expect(output.filtered_count).toBe(1);
+      expect(output.filter_reason).toBe('hallucinated_alert_ids');
+    });
+
+    it('does not call transformDiscoveriesToOutputFormat', async () => {
+      const stepDefinition = getDefaultValidationStepDefinition({
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      await stepDefinition.handler(mockContext as never);
+
+      expect(mockTransformDiscoveriesToOutputFormat).not.toHaveBeenCalled();
+    });
+
+    it('logs a warning about no discoveries to validate', async () => {
+      const stepDefinition = getDefaultValidationStepDefinition({
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      await stepDefinition.handler(mockContext as never);
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('No discoveries to validate after filtering')
+      );
+    });
+  });
+
+  describe('when no_discoveries filter reason is returned', () => {
+    beforeEach(() => {
+      mockFilterAndValidateDiscoveries.mockResolvedValue({
+        filteredCount: 0,
+        filterReason: 'no_discoveries',
+        shouldValidate: false,
+        validDiscoveries: [],
+      } as FilterResult<(typeof mockContext.input.attack_discoveries)[number]>);
+    });
+
+    it('returns filter_reason no_discoveries and filtered_count 0', async () => {
+      const stepDefinition = getDefaultValidationStepDefinition({
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      const result = await stepDefinition.handler(mockContext as never);
+
+      const output = getOutputOrThrow(result);
+
+      expect(output.filtered_count).toBe(0);
+      expect(output.filter_reason).toBe('no_discoveries');
+    });
+  });
+
+  describe('when authentication fails', () => {
+    beforeEach(() => {
+      mockAuthenticateAndGetSpace.mockRejectedValue(new Error('auth failed'));
+    });
+
+    it('logs an error and returns error result', async () => {
+      const stepDefinition = getDefaultValidationStepDefinition({
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      const result = await stepDefinition.handler(mockContext as never);
+
+      expect(mockContext.logger.error).toHaveBeenCalled();
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  describe('when connector_id is missing from api_config', () => {
+    beforeEach(() => {
+      mockFilterAndValidateDiscoveries.mockResolvedValue({
+        filteredCount: 0,
+        shouldValidate: true,
+        validDiscoveries: mockContext.input.attack_discoveries,
+      } as FilterResult<(typeof mockContext.input.attack_discoveries)[number]>);
+    });
+
+    it('logs an error about missing connector_id', async () => {
+      const contextWithoutConnectorId = {
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          api_config: {},
+        },
+      };
+
+      const stepDefinition = getDefaultValidationStepDefinition({
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      const result = await stepDefinition.handler(contextWithoutConnectorId as never);
+
+      expect(mockContext.logger.error).toHaveBeenCalledWith(
+        'Failed to validate discoveries',
+        expect.objectContaining({
+          message: 'Missing connector_id in api_config',
+        })
+      );
+      expect(result.output?.validated_discoveries ?? []).toEqual([]);
+    });
+  });
+
+  describe('when filterAndValidateDiscoveries throws an error', () => {
+    beforeEach(() => {
+      mockFilterAndValidateDiscoveries.mockRejectedValue(new Error('filter failed'));
+    });
+
+    it('logs the error to the context logger', async () => {
+      const stepDefinition = getDefaultValidationStepDefinition({
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      await stepDefinition.handler(mockContext as never);
+
+      expect(mockContext.logger.error).toHaveBeenCalledWith(
+        'Failed to validate discoveries',
+        expect.any(Error)
+      );
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/get_default_validation_step_definition.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/get_default_validation_step_definition.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import type { Logger } from '@kbn/core/server';
+import type { CoreStart } from '@kbn/core/server';
+
+import { createTracedLogger } from '@kbn/discoveries/impl/lib/create_traced_logger';
+import type { DiscoveriesPluginStartDeps } from '../../../types';
+import { resolveConnectorDetails } from '../../helpers/resolve_connector_details';
+import { DefaultValidationStepCommonDefinition } from '../../../../common/step_types/default_validation_step';
+import { authenticateAndGetSpace } from './helpers/authenticate_and_get_space';
+import { filterAndValidateDiscoveries } from './helpers/filter_and_validate_discoveries';
+import { handleValidationError } from './helpers/handle_validation_error';
+import { transformDiscoveriesToOutputFormat } from './helpers/transform_discoveries_to_output_format';
+
+/**
+ * Server-side implementation of the default validation step.
+ * Performs hallucination detection and deduplication on Attack Discoveries.
+ */
+export const getDefaultValidationStepDefinition = ({
+  getStartServices,
+  logger,
+}: {
+  getStartServices: () => Promise<{
+    coreStart: CoreStart;
+    pluginsStart: DiscoveriesPluginStartDeps;
+  }>;
+  logger: Logger;
+}) =>
+  createServerStepDefinition({
+    ...DefaultValidationStepCommonDefinition,
+    handler: async (context) => {
+      try {
+        const {
+          alerts_index_pattern: alertsIndexPattern = '.alerts-security.alerts-*',
+          api_config: apiConfig,
+          attack_discoveries: attackDiscoveries,
+          connector_name: connectorName,
+          generation_uuid: generationUuid,
+          replacements,
+        } = context.input;
+
+        const tracedLogger = createTracedLogger(logger, generationUuid);
+
+        tracedLogger.info('[VALIDATE] Handler starting...');
+        tracedLogger.debug(
+          () => `[VALIDATE] Context input: ${JSON.stringify(context.input, null, 2)}`
+        );
+
+        const { coreStart, pluginsStart } = await getStartServices();
+        const request = context.contextManager.getFakeRequest();
+
+        const { esClient } = await authenticateAndGetSpace({
+          coreStart,
+          pluginsStart,
+          request,
+        });
+
+        const parsedApiConfig = apiConfig as { connector_id?: string } | undefined;
+        const connectorId = parsedApiConfig?.connector_id;
+
+        if (!connectorId) {
+          throw new Error('Missing connector_id in api_config');
+        }
+
+        const actionsClient = await pluginsStart.actions.getActionsClientWithRequest(request);
+
+        const { connectorName: resolvedConnectorName } = await resolveConnectorDetails({
+          actionsClient,
+          connectorId,
+          connectorName,
+          inference: pluginsStart.inference,
+          logger,
+          request,
+        });
+
+        const { filteredCount, filterReason, shouldValidate, validDiscoveries } =
+          await filterAndValidateDiscoveries({
+            alertsIndexPattern,
+            attackDiscoveries,
+            contextLogger: context.logger,
+            esClient,
+            generationUuid,
+            logger: tracedLogger,
+          });
+
+        tracedLogger.info(
+          `[VALIDATE] Filter result: shouldValidate=${shouldValidate}, validDiscoveries=${
+            validDiscoveries.length
+          }, filteredCount=${filteredCount}, originalCount=${attackDiscoveries?.length ?? 0}`
+        );
+
+        if (!shouldValidate) {
+          tracedLogger.warn(
+            `[VALIDATE] No discoveries to validate after filtering. Original count: ${
+              attackDiscoveries?.length ?? 0
+            }`
+          );
+
+          return {
+            output: {
+              ...(filterReason != null ? { filter_reason: filterReason } : {}),
+              filtered_count: filteredCount,
+              validated_discoveries: [],
+            },
+          };
+        }
+
+        context.logger.info(
+          `Validating ${validDiscoveries.length} attack discoveries (generation: ${generationUuid})`
+        );
+
+        const transformedDiscoveries = transformDiscoveriesToOutputFormat({
+          attackDiscoveries: validDiscoveries,
+          connectorId,
+          connectorName: resolvedConnectorName,
+          generationUuid,
+          replacements,
+        });
+
+        return {
+          output: {
+            ...(filterReason != null ? { filter_reason: filterReason } : {}),
+            filtered_count: filteredCount,
+            validated_discoveries: transformedDiscoveries,
+          },
+        };
+      } catch (error) {
+        return handleValidationError({
+          contextLogger: context.logger,
+          error,
+          logger,
+        });
+      }
+    },
+  });

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/helpers/authenticate_and_get_space.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/helpers/authenticate_and_get_space.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  AuthenticatedUser,
+  CoreStart,
+  ElasticsearchClient,
+  KibanaRequest,
+} from '@kbn/core/server';
+
+import { getSpaceId } from '@kbn/discoveries/impl/lib/helpers/get_space_id';
+import type { DiscoveriesPluginStartDeps } from '../../../../types';
+
+export const authenticateAndGetSpace = async ({
+  coreStart,
+  pluginsStart,
+  request,
+}: {
+  coreStart: CoreStart;
+  pluginsStart: DiscoveriesPluginStartDeps;
+  request: KibanaRequest;
+}): Promise<{
+  authenticationInfo: unknown;
+  authenticatedUser: AuthenticatedUser;
+  esClient: ElasticsearchClient;
+  spaceId: string;
+}> => {
+  const authenticationInfo = await coreStart.elasticsearch.client
+    .asScoped(request)
+    .asCurrentUser.security.authenticate();
+
+  const authenticatedUser: AuthenticatedUser = {
+    ...(authenticationInfo as unknown as AuthenticatedUser),
+    authentication_provider: { name: 'workflows', type: 'workflows' },
+    elastic_cloud_user: false,
+  };
+
+  const esClient = coreStart.elasticsearch.client.asScoped(request).asCurrentUser;
+
+  const spaceId = getSpaceId({
+    request,
+    spaces: pluginsStart.spaces?.spacesService,
+  });
+
+  return {
+    authenticationInfo,
+    authenticatedUser,
+    esClient,
+    spaceId,
+  };
+};

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/helpers/filter_and_validate_discoveries.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/helpers/filter_and_validate_discoveries.test.ts
@@ -1,0 +1,514 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { DiscoveryWithAlertIds } from '@kbn/discoveries/impl/attack_discovery/hallucination_detection';
+import { filterHallucinatedAlerts } from '@kbn/discoveries/impl/attack_discovery/hallucination_detection';
+
+import { filterAndValidateDiscoveries } from './filter_and_validate_discoveries';
+
+jest.mock('@kbn/discoveries/impl/attack_discovery/hallucination_detection', () => ({
+  filterHallucinatedAlerts: jest.fn(),
+  getAlertIds: jest.requireActual('@kbn/discoveries/impl/attack_discovery/hallucination_detection')
+    .getAlertIds,
+}));
+
+const mockFilterHallucinatedAlerts = filterHallucinatedAlerts as jest.MockedFunction<
+  typeof filterHallucinatedAlerts
+>;
+
+describe('filterAndValidateDiscoveries', () => {
+  const mockLogger = {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  } as unknown as Logger;
+
+  const mockContextLogger = {
+    info: jest.fn(),
+  };
+
+  const mockEsClient = {} as unknown as ElasticsearchClient;
+
+  const alertsIndexPattern = '.alerts-security.alerts-default';
+  const generationUuid = 'test-generation-uuid';
+
+  const mockDiscovery: DiscoveryWithAlertIds = {
+    alertIds: ['alert-1', 'alert-2'],
+    title: 'Test Discovery',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when attackDiscoveries is null', () => {
+    it('returns shouldValidate: false and empty validDiscoveries', async () => {
+      const result = await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: null,
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(result).toEqual({
+        filteredCount: 0,
+        filterReason: 'no_discoveries',
+        shouldValidate: false,
+        validDiscoveries: [],
+      });
+    });
+
+    it('logs a warning about no discoveries to validate', async () => {
+      await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: null,
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('No attack discoveries to validate')
+      );
+    });
+
+    it('logs to the context logger about no discoveries', async () => {
+      await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: null,
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(mockContextLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('No attack discoveries to validate')
+      );
+    });
+  });
+
+  describe('when attackDiscoveries is undefined', () => {
+    it('returns shouldValidate: false with no_discoveries filter reason', async () => {
+      const result = await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: undefined,
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(result).toEqual({
+        filteredCount: 0,
+        filterReason: 'no_discoveries',
+        shouldValidate: false,
+        validDiscoveries: [],
+      });
+    });
+  });
+
+  describe('when attackDiscoveries is an empty array', () => {
+    it('returns shouldValidate: false with no_discoveries filter reason', async () => {
+      const result = await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: [],
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(result).toEqual({
+        filteredCount: 0,
+        filterReason: 'no_discoveries',
+        shouldValidate: false,
+        validDiscoveries: [],
+      });
+    });
+  });
+
+  describe('when all discoveries are filtered out due to hallucinated alert IDs', () => {
+    beforeEach(() => {
+      mockFilterHallucinatedAlerts.mockResolvedValue([]);
+    });
+
+    it('returns shouldValidate: false with hallucinated_alert_ids filter reason', async () => {
+      const result = await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: [mockDiscovery],
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(result).toEqual({
+        filteredCount: 1,
+        filterReason: 'hallucinated_alert_ids',
+        shouldValidate: false,
+        validDiscoveries: [],
+      });
+    });
+
+    it('logs a warning about hallucinated alert IDs', async () => {
+      await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: [mockDiscovery],
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'All attack discoveries were filtered out due to hallucinated alert IDs'
+        )
+      );
+    });
+
+    it('logs sample filtered alert IDs for debugging', async () => {
+      await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: [mockDiscovery],
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Sample filtered alert IDs')
+      );
+    });
+
+    it('logs to the context logger for event log tracking', async () => {
+      await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: [mockDiscovery],
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(mockContextLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('All attack discoveries were filtered out')
+      );
+    });
+  });
+
+  describe('when some discoveries remain after filtering', () => {
+    beforeEach(() => {
+      mockFilterHallucinatedAlerts.mockResolvedValue([mockDiscovery]);
+    });
+
+    it('returns shouldValidate: true with zero filteredCount when none were filtered', async () => {
+      const result = await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: [mockDiscovery],
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(result).toEqual({
+        filteredCount: 0,
+        shouldValidate: true,
+        validDiscoveries: [mockDiscovery],
+      });
+    });
+
+    it('does not include filterReason when no discoveries were filtered', async () => {
+      const result = await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: [mockDiscovery],
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(result.filterReason).toBeUndefined();
+    });
+
+    it('logs the filter results at info level', async () => {
+      await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: [mockDiscovery],
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'After hallucination filter: 1/1 discoveries remain (1 verified + 0 unverifiable)'
+        )
+      );
+    });
+  });
+
+  describe('when some discoveries are filtered by hallucination detection', () => {
+    const discovery1: DiscoveryWithAlertIds = {
+      alertIds: ['alert-1'],
+      title: 'Discovery 1',
+    };
+
+    const discovery2: DiscoveryWithAlertIds = {
+      alertIds: ['alert-2'],
+      title: 'Discovery 2',
+    };
+
+    beforeEach(() => {
+      mockFilterHallucinatedAlerts.mockResolvedValue([discovery1]);
+    });
+
+    it('returns filteredCount matching the number of removed discoveries', async () => {
+      const result = await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: [discovery1, discovery2],
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(result.filteredCount).toBe(1);
+    });
+
+    it('returns hallucinated_alert_ids as the filterReason', async () => {
+      const result = await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: [discovery1, discovery2],
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(result.filterReason).toBe('hallucinated_alert_ids');
+    });
+  });
+
+  describe('when discoveries use snake_case alert_ids', () => {
+    const snakeCaseDiscovery = {
+      alert_ids: ['alert-1', 'alert-2'],
+      details_markdown: 'Test details',
+      entity_summary_markdown: 'Test entity summary',
+      mitre_attack_tactics: ['Initial Access'],
+      summary_markdown: 'Test summary',
+      title: 'Test Discovery',
+    } as unknown as DiscoveryWithAlertIds;
+
+    beforeEach(() => {
+      mockFilterHallucinatedAlerts.mockResolvedValue([]);
+    });
+
+    it('logs sample filtered alert IDs from snake_case properties', async () => {
+      await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: [snakeCaseDiscovery],
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('["alert-1","alert-2"]')
+      );
+    });
+  });
+
+  describe('when discoveries are a mix of verifiable and unverifiable', () => {
+    const verifiableDiscovery: DiscoveryWithAlertIds = {
+      alertIds: ['alert-1', 'alert-2'],
+      title: 'Verifiable Discovery',
+    };
+
+    const unverifiableDiscovery: DiscoveryWithAlertIds = {
+      alertIds: [],
+      title: 'Unverifiable Discovery (empty alertIds)',
+    };
+
+    const unverifiableDiscoveryNoField: DiscoveryWithAlertIds = {
+      title: 'Unverifiable Discovery (no alertIds field)',
+    };
+
+    describe('when verifiable discoveries pass hallucination detection', () => {
+      beforeEach(() => {
+        mockFilterHallucinatedAlerts.mockResolvedValue([verifiableDiscovery]);
+      });
+
+      it('includes both verified and unverifiable discoveries in the result', async () => {
+        const result = await filterAndValidateDiscoveries({
+          alertsIndexPattern,
+          attackDiscoveries: [verifiableDiscovery, unverifiableDiscovery],
+          contextLogger: mockContextLogger,
+          esClient: mockEsClient,
+          generationUuid,
+          logger: mockLogger,
+        });
+
+        expect(result.validDiscoveries).toEqual(
+          expect.arrayContaining([verifiableDiscovery, unverifiableDiscovery])
+        );
+        expect(result.validDiscoveries).toHaveLength(2);
+      });
+
+      it('returns shouldValidate: true', async () => {
+        const result = await filterAndValidateDiscoveries({
+          alertsIndexPattern,
+          attackDiscoveries: [verifiableDiscovery, unverifiableDiscovery],
+          contextLogger: mockContextLogger,
+          esClient: mockEsClient,
+          generationUuid,
+          logger: mockLogger,
+        });
+
+        expect(result.shouldValidate).toBe(true);
+      });
+
+      it('passes only verifiable discoveries to filterHallucinatedAlerts', async () => {
+        await filterAndValidateDiscoveries({
+          alertsIndexPattern,
+          attackDiscoveries: [verifiableDiscovery, unverifiableDiscovery],
+          contextLogger: mockContextLogger,
+          esClient: mockEsClient,
+          generationUuid,
+          logger: mockLogger,
+        });
+
+        expect(mockFilterHallucinatedAlerts).toHaveBeenCalledWith(
+          expect.objectContaining({
+            attackDiscoveries: [verifiableDiscovery],
+          })
+        );
+      });
+
+      it('includes unverifiable discoveries that have no alertIds field', async () => {
+        const result = await filterAndValidateDiscoveries({
+          alertsIndexPattern,
+          attackDiscoveries: [verifiableDiscovery, unverifiableDiscoveryNoField],
+          contextLogger: mockContextLogger,
+          esClient: mockEsClient,
+          generationUuid,
+          logger: mockLogger,
+        });
+
+        expect(result.validDiscoveries).toEqual(
+          expect.arrayContaining([verifiableDiscovery, unverifiableDiscoveryNoField])
+        );
+        expect(result.validDiscoveries).toHaveLength(2);
+      });
+    });
+
+    describe('when all verifiable discoveries are filtered out by hallucination detection', () => {
+      beforeEach(() => {
+        mockFilterHallucinatedAlerts.mockResolvedValue([]);
+      });
+
+      it('still includes unverifiable discoveries', async () => {
+        const result = await filterAndValidateDiscoveries({
+          alertsIndexPattern,
+          attackDiscoveries: [verifiableDiscovery, unverifiableDiscovery],
+          contextLogger: mockContextLogger,
+          esClient: mockEsClient,
+          generationUuid,
+          logger: mockLogger,
+        });
+
+        expect(result.validDiscoveries).toEqual([unverifiableDiscovery]);
+      });
+
+      it('returns shouldValidate: true when unverifiable discoveries remain', async () => {
+        const result = await filterAndValidateDiscoveries({
+          alertsIndexPattern,
+          attackDiscoveries: [verifiableDiscovery, unverifiableDiscovery],
+          contextLogger: mockContextLogger,
+          esClient: mockEsClient,
+          generationUuid,
+          logger: mockLogger,
+        });
+
+        expect(result.shouldValidate).toBe(true);
+      });
+
+      it('returns filteredCount of 1 and hallucinated_alert_ids reason', async () => {
+        const result = await filterAndValidateDiscoveries({
+          alertsIndexPattern,
+          attackDiscoveries: [verifiableDiscovery, unverifiableDiscovery],
+          contextLogger: mockContextLogger,
+          esClient: mockEsClient,
+          generationUuid,
+          logger: mockLogger,
+        });
+
+        expect(result.filteredCount).toBe(1);
+        expect(result.filterReason).toBe('hallucinated_alert_ids');
+      });
+    });
+
+    describe('when multiple unverifiable discoveries are mixed in', () => {
+      const anotherUnverifiable: DiscoveryWithAlertIds = {
+        alertIds: [],
+        title: 'Another Unverifiable Discovery',
+      };
+
+      beforeEach(() => {
+        mockFilterHallucinatedAlerts.mockResolvedValue([verifiableDiscovery]);
+      });
+
+      it('includes all unverifiable discoveries alongside verified ones', async () => {
+        const result = await filterAndValidateDiscoveries({
+          alertsIndexPattern,
+          attackDiscoveries: [verifiableDiscovery, unverifiableDiscovery, anotherUnverifiable],
+          contextLogger: mockContextLogger,
+          esClient: mockEsClient,
+          generationUuid,
+          logger: mockLogger,
+        });
+
+        expect(result.validDiscoveries).toEqual(
+          expect.arrayContaining([verifiableDiscovery, unverifiableDiscovery, anotherUnverifiable])
+        );
+        expect(result.validDiscoveries).toHaveLength(3);
+      });
+    });
+  });
+
+  describe('when all discoveries have empty alert IDs', () => {
+    const emptyAlertIdsDiscovery: DiscoveryWithAlertIds = {
+      alertIds: [],
+      title: 'No alert IDs',
+    };
+
+    it('returns filteredCount of 0 and no filterReason', async () => {
+      const result = await filterAndValidateDiscoveries({
+        alertsIndexPattern,
+        attackDiscoveries: [emptyAlertIdsDiscovery],
+        contextLogger: mockContextLogger,
+        esClient: mockEsClient,
+        generationUuid,
+        logger: mockLogger,
+      });
+
+      expect(result.filteredCount).toBe(0);
+      expect(result.filterReason).toBeUndefined();
+      expect(result.shouldValidate).toBe(true);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/helpers/filter_and_validate_discoveries.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/helpers/filter_and_validate_discoveries.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { DiscoveryWithAlertIds } from '@kbn/discoveries/impl/attack_discovery/hallucination_detection';
+import {
+  filterHallucinatedAlerts,
+  getAlertIds,
+} from '@kbn/discoveries/impl/attack_discovery/hallucination_detection';
+
+export interface FilterResult<T> {
+  filteredCount: number;
+  filterReason?: string;
+  shouldValidate: boolean;
+  validDiscoveries: T[];
+}
+
+export const filterAndValidateDiscoveries = async <T extends DiscoveryWithAlertIds>({
+  alertsIndexPattern,
+  attackDiscoveries,
+  contextLogger,
+  esClient,
+  generationUuid,
+  logger,
+}: {
+  alertsIndexPattern: string;
+  attackDiscoveries: T[] | null | undefined;
+  contextLogger: { info: (message: string) => void };
+  esClient: ElasticsearchClient;
+  generationUuid: string;
+  logger: Logger;
+}): Promise<FilterResult<T>> => {
+  logger.info(
+    `[VALIDATE][FILTER] Input: attackDiscoveries=${
+      attackDiscoveries?.length ?? 'null'
+    }, alertsIndexPattern=${alertsIndexPattern}`
+  );
+
+  if (!attackDiscoveries || attackDiscoveries.length === 0) {
+    const message = 'No attack discoveries to validate';
+    contextLogger.info(message);
+    logger.warn(`[VALIDATE][FILTER] ${message}`);
+
+    return {
+      filteredCount: 0,
+      filterReason: 'no_discoveries',
+      shouldValidate: false,
+      validDiscoveries: [] as T[],
+    };
+  }
+
+  logger.info(
+    `[VALIDATE][FILTER] Filtering ${attackDiscoveries.length} discoveries against alertsIndexPattern: ${alertsIndexPattern}`
+  );
+
+  const verifiableDiscoveries = attackDiscoveries.filter(
+    (discovery) => getAlertIds(discovery).length > 0
+  );
+  const unverifiableDiscoveries = attackDiscoveries.filter(
+    (discovery) => getAlertIds(discovery).length === 0
+  );
+
+  if (verifiableDiscoveries.length === 0) {
+    logger.warn(
+      '[VALIDATE][FILTER] Skipping hallucination detection because all discoveries have empty alert IDs'
+    );
+    return {
+      filteredCount: 0,
+      shouldValidate: true,
+      validDiscoveries: attackDiscoveries,
+    };
+  }
+
+  if (unverifiableDiscoveries.length > 0) {
+    logger.info(
+      `[VALIDATE][FILTER] ${unverifiableDiscoveries.length} unverifiable discovery(ies) will bypass hallucination detection`
+    );
+  }
+
+  const validVerifiableDiscoveries = await filterHallucinatedAlerts({
+    alertsIndexPattern,
+    attackDiscoveries: verifiableDiscoveries,
+    esClient,
+    logger,
+  });
+
+  const validDiscoveries = [...validVerifiableDiscoveries, ...unverifiableDiscoveries];
+  const filteredCount = attackDiscoveries.length - validDiscoveries.length;
+
+  logger.info(
+    `[VALIDATE][FILTER] After hallucination filter: ${validDiscoveries.length}/${attackDiscoveries.length} discoveries remain (${validVerifiableDiscoveries.length} verified + ${unverifiableDiscoveries.length} unverifiable)`
+  );
+
+  if (validDiscoveries.length === 0) {
+    const message = 'All attack discoveries were filtered out due to hallucinated alert IDs';
+    contextLogger.info(message);
+    logger.warn(`[VALIDATE][FILTER] ${message}`);
+
+    const alertIds = attackDiscoveries.flatMap((d) => getAlertIds(d)).slice(0, 10);
+    logger.warn(`[VALIDATE][FILTER] Sample filtered alert IDs: ${JSON.stringify(alertIds)}`);
+
+    return {
+      filteredCount,
+      filterReason: 'hallucinated_alert_ids',
+      shouldValidate: false,
+      validDiscoveries: [] as T[],
+    };
+  }
+
+  return {
+    filteredCount,
+    ...(filteredCount > 0 ? { filterReason: 'hallucinated_alert_ids' } : {}),
+    shouldValidate: true,
+    validDiscoveries,
+  };
+};

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/helpers/handle_validation_error.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/helpers/handle_validation_error.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+
+export const handleValidationError = ({
+  contextLogger,
+  error,
+  logger,
+}: {
+  contextLogger: { error: (message: string, error?: Error) => void };
+  error: unknown;
+  logger: Logger;
+}): { error: Error } => {
+  logger.debug(() => `🔍 [VALIDATE] ERROR: ${error}`);
+
+  contextLogger.error('Failed to validate discoveries', error instanceof Error ? error : undefined);
+
+  return {
+    error: new Error(error instanceof Error ? error.message : 'Failed to validate discoveries'),
+  };
+};

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/helpers/transform_discoveries_to_output_format/index.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/helpers/transform_discoveries_to_output_format/index.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { transformDiscoveriesToOutputFormat } from '.';
+
+const mockUuid = 'mock-generated-uuid';
+jest.mock('uuid', () => ({
+  v4: () => mockUuid,
+}));
+
+describe('transformDiscoveriesToOutputFormat', () => {
+  const baseParams = {
+    connectorId: 'connector-1',
+    connectorName: 'Test Connector',
+    generationUuid: 'generation-1',
+  };
+
+  const discoveryWithAllFields = {
+    alert_ids: ['alert-1', 'alert-2'],
+    details_markdown: 'Details about the attack',
+    entity_summary_markdown: 'Entity summary',
+    id: 'existing-id',
+    mitre_attack_tactics: ['Initial Access', 'Persistence'],
+    summary_markdown: 'Summary of the attack',
+    timestamp: '2025-06-15T10:00:00.000Z',
+    title: 'Test Attack Discovery',
+  };
+
+  const discoveryMinimal = {
+    alert_ids: ['alert-3'],
+    details_markdown: 'Minimal details',
+    summary_markdown: 'Minimal summary',
+    title: 'Minimal Discovery',
+  };
+
+  it('returns an empty array when given no discoveries', () => {
+    const result = transformDiscoveriesToOutputFormat({
+      ...baseParams,
+      attackDiscoveries: [],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('maps all fields from a fully-populated discovery', () => {
+    const result = transformDiscoveriesToOutputFormat({
+      ...baseParams,
+      attackDiscoveries: [discoveryWithAllFields],
+      replacements: { 'uuid-1': 'original-value' },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      alert_ids: ['alert-1', 'alert-2'],
+      connector_id: 'connector-1',
+      connector_name: 'Test Connector',
+      details_markdown: 'Details about the attack',
+      entity_summary_markdown: 'Entity summary',
+      generation_uuid: 'generation-1',
+      id: 'existing-id',
+      mitre_attack_tactics: ['Initial Access', 'Persistence'],
+      replacements: { 'uuid-1': 'original-value' },
+      summary_markdown: 'Summary of the attack',
+      timestamp: '2025-06-15T10:00:00.000Z',
+      title: 'Test Attack Discovery',
+    });
+  });
+
+  it('generates a UUID when the discovery has no id', () => {
+    const result = transformDiscoveriesToOutputFormat({
+      ...baseParams,
+      attackDiscoveries: [discoveryMinimal],
+    });
+
+    expect(result[0].id).toBe(mockUuid);
+  });
+
+  it('uses the discovery id when present', () => {
+    const result = transformDiscoveriesToOutputFormat({
+      ...baseParams,
+      attackDiscoveries: [discoveryWithAllFields],
+    });
+
+    expect(result[0].id).toBe('existing-id');
+  });
+
+  it('generates a timestamp when the discovery has no timestamp', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-07-01T12:00:00.000Z'));
+
+    const result = transformDiscoveriesToOutputFormat({
+      ...baseParams,
+      attackDiscoveries: [discoveryMinimal],
+    });
+
+    expect(result[0].timestamp).toBe('2025-07-01T12:00:00.000Z');
+
+    jest.useRealTimers();
+  });
+
+  it('uses the discovery timestamp when present', () => {
+    const result = transformDiscoveriesToOutputFormat({
+      ...baseParams,
+      attackDiscoveries: [discoveryWithAllFields],
+    });
+
+    expect(result[0].timestamp).toBe('2025-06-15T10:00:00.000Z');
+  });
+
+  it('omits optional fields that are not present in the discovery', () => {
+    const result = transformDiscoveriesToOutputFormat({
+      ...baseParams,
+      attackDiscoveries: [discoveryMinimal],
+    });
+
+    expect(result[0]).not.toHaveProperty('entity_summary_markdown');
+    expect(result[0]).not.toHaveProperty('mitre_attack_tactics');
+    expect(result[0]).not.toHaveProperty('replacements');
+  });
+
+  it('omits replacements from output when not provided', () => {
+    const result = transformDiscoveriesToOutputFormat({
+      ...baseParams,
+      attackDiscoveries: [discoveryWithAllFields],
+    });
+
+    expect(result[0]).not.toHaveProperty('replacements');
+  });
+
+  it('transforms multiple discoveries', () => {
+    const result = transformDiscoveriesToOutputFormat({
+      ...baseParams,
+      attackDiscoveries: [discoveryWithAllFields, discoveryMinimal],
+      replacements: { key: 'value' },
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].title).toBe('Test Attack Discovery');
+    expect(result[1].title).toBe('Minimal Discovery');
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/helpers/transform_discoveries_to_output_format/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/helpers/transform_discoveries_to_output_format/index.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+
+interface RawDiscovery {
+  alert_ids: string[];
+  details_markdown: string;
+  entity_summary_markdown?: string;
+  id?: string;
+  mitre_attack_tactics?: string[];
+  summary_markdown: string;
+  timestamp?: string;
+  title: string;
+}
+
+interface TransformedDiscovery {
+  alert_ids: string[];
+  connector_id: string;
+  connector_name: string;
+  details_markdown: string;
+  entity_summary_markdown?: string;
+  generation_uuid: string;
+  id: string;
+  mitre_attack_tactics?: string[];
+  replacements?: Record<string, string>;
+  summary_markdown: string;
+  timestamp: string;
+  title: string;
+}
+
+/**
+ * Transforms raw generation-format discoveries into the same shape that
+ * `validateAttackDiscoveries` returns, without touching Elasticsearch.
+ */
+export const transformDiscoveriesToOutputFormat = ({
+  attackDiscoveries,
+  connectorId,
+  connectorName,
+  generationUuid,
+  replacements,
+}: {
+  attackDiscoveries: RawDiscovery[];
+  connectorId: string;
+  connectorName: string;
+  generationUuid: string;
+  replacements?: Record<string, string>;
+}): TransformedDiscovery[] =>
+  attackDiscoveries.map((discovery) => ({
+    alert_ids: discovery.alert_ids,
+    connector_id: connectorId,
+    connector_name: connectorName,
+    details_markdown: discovery.details_markdown,
+    ...(discovery.entity_summary_markdown != null
+      ? { entity_summary_markdown: discovery.entity_summary_markdown }
+      : {}),
+    generation_uuid: generationUuid,
+    id: discovery.id ?? uuidv4(),
+    ...(discovery.mitre_attack_tactics != null
+      ? { mitre_attack_tactics: discovery.mitre_attack_tactics }
+      : {}),
+    ...(replacements != null ? { replacements } : {}),
+    summary_markdown: discovery.summary_markdown,
+    timestamp: discovery.timestamp ?? new Date().toISOString(),
+    title: discovery.title,
+  }));

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/default_validation_step/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getDefaultValidationStepDefinition } from './get_default_validation_step_definition';

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step.test.ts
@@ -1,0 +1,846 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import { loggerMock } from '@kbn/logging-mocks';
+import { coreMock } from '@kbn/core/server/mocks';
+import { actionsClientMock } from '@kbn/actions-plugin/server/actions_client/actions_client.mock';
+import type { AttackDiscovery } from '@kbn/elastic-assistant-common';
+import { getGenerateStepDefinition } from './generate_step';
+import { GenerateStepTypeId } from '../../../common/step_types/generate_step';
+import { invokeAttackDiscoveryGraphWithAlerts } from '@kbn/discoveries/impl/attack_discovery/graphs/invoke_graph_with_alerts';
+import { getAttackDiscoveryPrompts } from '../../lib/attack_discovery/prompts';
+
+jest.mock('@kbn/discoveries/impl/attack_discovery/graphs/invoke_graph_with_alerts');
+jest.mock('../../lib/attack_discovery/prompts');
+
+const mockInvokeAttackDiscoveryGraphWithAlerts = invokeAttackDiscoveryGraphWithAlerts as jest.Mock;
+const mockGetAttackDiscoveryPrompts = getAttackDiscoveryPrompts as jest.Mock;
+
+describe('GenerateStepDefinition', () => {
+  const mockLogger: Logger = loggerMock.create();
+  const mockCoreStart = coreMock.createStart();
+  const mockActionsClient = actionsClientMock.create();
+  const mockEsClient = mockCoreStart.elasticsearch.client.asScoped({} as any).asCurrentUser;
+  const mockEventLogger = {
+    logEvent: jest.fn(),
+  };
+
+  const mockGetStartServices = jest.fn().mockResolvedValue({
+    coreStart: mockCoreStart,
+    pluginsStart: {
+      actions: {
+        getActionsClientWithRequest: jest.fn().mockResolvedValue(mockActionsClient),
+      },
+    },
+  });
+
+  const mockGetEventLogger = jest.fn().mockResolvedValue(mockEventLogger);
+  const mockGetEventLogIndex = jest.fn().mockResolvedValue('.kibana-event-log-*');
+
+  const defaultInput = {
+    alerts: [
+      'timestamp,2025-01-01T00:00:00Z,host.name,server1,user.name,admin',
+      'timestamp,2025-01-01T00:01:00Z,host.name,server1,user.name,admin',
+    ],
+    api_config: {
+      action_type_id: '.gemini',
+      connector_id: 'test-connector',
+      model: 'test-model',
+    },
+    replacements: { server1: 'SERVER_001' },
+    size: 10,
+  };
+
+  const mockContext = {
+    abortSignal: undefined,
+    contextManager: {
+      getContext: jest.fn().mockReturnValue({
+        execution: {
+          id: 'test-execution-id',
+        },
+        workflow: {
+          id: 'test-workflow-id',
+          spaceId: 'default',
+        },
+      }),
+      getFakeRequest: jest.fn().mockReturnValue({}),
+    },
+    input: defaultInput,
+    logger: mockLogger,
+  };
+
+  const mockPrompts = {
+    continue: 'continue prompt',
+    default: 'default prompt',
+    detailsMarkdown: 'details markdown',
+    entitySummaryMarkdown: 'entity summary',
+    insights: 'insights prompt',
+    mitreAttackTactics: 'mitre tactics',
+    refine: 'refine prompt',
+    summaryMarkdown: 'summary markdown',
+    title: 'title prompt',
+  };
+
+  const mockDiscoveriesCamelCase: AttackDiscovery[] = [
+    {
+      alertIds: ['alert-1', 'alert-2'],
+      detailsMarkdown: 'Attack details',
+      entitySummaryMarkdown: 'Entity summary',
+      id: 'discovery-1',
+      mitreAttackTactics: ['Initial Access', 'Execution'],
+      summaryMarkdown: 'Summary',
+      timestamp: '2025-01-01T00:00:00Z',
+      title: 'Attack Title',
+    },
+  ];
+
+  let stepDefinition: ReturnType<typeof getGenerateStepDefinition>;
+
+  const getOutputOrThrow = <T>(result: { output?: T }): T => {
+    if (!result.output) {
+      throw new Error('Expected result.output to be defined');
+    }
+
+    return result.output;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAttackDiscoveryPrompts.mockResolvedValue(mockPrompts);
+
+    stepDefinition = getGenerateStepDefinition({
+      connectorTimeout: 60000,
+      getEventLogIndex: mockGetEventLogIndex,
+      getEventLogger: mockGetEventLogger,
+      getStartServices: mockGetStartServices,
+      langSmithApiKey: undefined,
+      langSmithProject: undefined,
+      logger: mockLogger,
+    });
+  });
+
+  describe('when zero alerts are provided', () => {
+    it('returns null attack_discoveries in output', async () => {
+      const context = {
+        ...mockContext,
+        input: {
+          ...defaultInput,
+          alerts: [],
+        },
+      };
+
+      const result = await stepDefinition.handler(context as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.attack_discoveries).toBeNull();
+    });
+
+    it('does not invoke the graph', async () => {
+      const context = {
+        ...mockContext,
+        input: {
+          ...defaultInput,
+          alerts: [],
+        },
+      };
+
+      await stepDefinition.handler(context as any);
+
+      expect(mockInvokeAttackDiscoveryGraphWithAlerts).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('successful generation', () => {
+    beforeEach(() => {
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: mockDiscoveriesCamelCase,
+        replacements: { server1: 'SERVER_001' },
+      });
+    });
+
+    it('returns attack_discoveries in output', async () => {
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.attack_discoveries).toBeDefined();
+    });
+
+    it('returns attack_discoveries with alert_ids in snake_case', async () => {
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      if (!output.attack_discoveries) throw new Error('Expected attack_discoveries to be defined');
+
+      expect(output.attack_discoveries[0].alert_ids).toEqual(['alert-1', 'alert-2']);
+    });
+
+    it('returns attack_discoveries with details_markdown in snake_case', async () => {
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      if (!output.attack_discoveries) throw new Error('Expected attack_discoveries to be defined');
+
+      expect(output.attack_discoveries[0].details_markdown).toBe('Attack details');
+    });
+
+    it('returns attack_discoveries with entity_summary_markdown in snake_case', async () => {
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      if (!output.attack_discoveries) throw new Error('Expected attack_discoveries to be defined');
+
+      expect(output.attack_discoveries[0].entity_summary_markdown).toBe('Entity summary');
+    });
+
+    it('returns attack_discoveries with mitre_attack_tactics in snake_case', async () => {
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      if (!output.attack_discoveries) throw new Error('Expected attack_discoveries to be defined');
+
+      expect(output.attack_discoveries[0].mitre_attack_tactics).toEqual([
+        'Initial Access',
+        'Execution',
+      ]);
+    });
+
+    it('returns attack_discoveries with summary_markdown in snake_case', async () => {
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      if (!output.attack_discoveries) throw new Error('Expected attack_discoveries to be defined');
+
+      expect(output.attack_discoveries[0].summary_markdown).toBe('Summary');
+    });
+
+    it('returns execution_uuid from context', async () => {
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.execution_uuid).toBe('test-execution-id');
+    });
+
+    it('returns replacements from graph', async () => {
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.replacements).toEqual({ server1: 'SERVER_001' });
+    });
+  });
+
+  describe('updated replacements', () => {
+    it('returns updated replacements when graph provides new ones', async () => {
+      const updatedReplacements = { server1: 'SERVER_001', server2: 'SERVER_002' };
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: mockDiscoveriesCamelCase,
+        replacements: updatedReplacements,
+      });
+
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.replacements).toEqual(updatedReplacements);
+    });
+  });
+
+  describe('null and empty discoveries', () => {
+    it('returns null when graph returns null discoveries', async () => {
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: null,
+        replacements: {},
+      });
+
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.attack_discoveries).toBeNull();
+    });
+
+    it('returns empty array when graph returns empty array', async () => {
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: [],
+        replacements: {},
+      });
+
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      expect(output.attack_discoveries).toEqual([]);
+    });
+  });
+
+  describe('graph invocation', () => {
+    beforeEach(() => {
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: [],
+        replacements: {},
+      });
+    });
+
+    it('invokes graph with actionsClient', async () => {
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockInvokeAttackDiscoveryGraphWithAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionsClient: mockActionsClient,
+        })
+      );
+    });
+
+    it('invokes graph with alerts as Documents', async () => {
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockInvokeAttackDiscoveryGraphWithAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          alerts: expect.arrayContaining([
+            expect.objectContaining({
+              metadata: {},
+              pageContent: 'timestamp,2025-01-01T00:00:00Z,host.name,server1,user.name,admin',
+            }),
+          ]),
+        })
+      );
+    });
+
+    it('invokes graph with apiConfig', async () => {
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockInvokeAttackDiscoveryGraphWithAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiConfig: {
+            action_type_id: '.gemini',
+            connector_id: 'test-connector',
+            model: 'test-model',
+          },
+        })
+      );
+    });
+
+    it('invokes graph with connectorTimeout', async () => {
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockInvokeAttackDiscoveryGraphWithAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connectorTimeout: 60000,
+        })
+      );
+    });
+
+    it('invokes graph with esClient', async () => {
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockInvokeAttackDiscoveryGraphWithAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          esClient: mockEsClient,
+        })
+      );
+    });
+
+    it('invokes graph with logger', async () => {
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockInvokeAttackDiscoveryGraphWithAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          logger: mockLogger,
+        })
+      );
+    });
+
+    it('invokes graph with prompts', async () => {
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockInvokeAttackDiscoveryGraphWithAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompts: mockPrompts,
+        })
+      );
+    });
+
+    it('invokes graph with replacements', async () => {
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockInvokeAttackDiscoveryGraphWithAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          replacements: { server1: 'SERVER_001' },
+        })
+      );
+    });
+
+    it('invokes graph with size', async () => {
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockInvokeAttackDiscoveryGraphWithAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          size: 10,
+        })
+      );
+    });
+  });
+
+  describe('langsmith configuration', () => {
+    it('passes langSmithApiKey when provided', async () => {
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: [],
+        replacements: {},
+      });
+
+      const stepDefWithLangsmith = getGenerateStepDefinition({
+        connectorTimeout: 60000,
+        getEventLogIndex: mockGetEventLogIndex,
+        getEventLogger: mockGetEventLogger,
+        getStartServices: mockGetStartServices,
+        langSmithApiKey: 'test-api-key',
+        langSmithProject: 'test-project',
+        logger: mockLogger,
+      });
+
+      await stepDefWithLangsmith.handler(mockContext as any);
+
+      expect(mockInvokeAttackDiscoveryGraphWithAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          langSmithApiKey: 'test-api-key',
+        })
+      );
+    });
+
+    it('passes langSmithProject when provided', async () => {
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: [],
+        replacements: {},
+      });
+
+      const stepDefWithLangsmith = getGenerateStepDefinition({
+        connectorTimeout: 60000,
+        getEventLogIndex: mockGetEventLogIndex,
+        getEventLogger: mockGetEventLogger,
+        getStartServices: mockGetStartServices,
+        langSmithApiKey: 'test-api-key',
+        langSmithProject: 'test-project',
+        logger: mockLogger,
+      });
+
+      await stepDefWithLangsmith.handler(mockContext as any);
+
+      expect(mockInvokeAttackDiscoveryGraphWithAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          langSmithProject: 'test-project',
+        })
+      );
+    });
+  });
+
+  describe('abortSignal handling', () => {
+    it('passes abortSignal to graph invocation', async () => {
+      const mockAbortSignal = new AbortController().signal;
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: [],
+        replacements: {},
+      });
+
+      const contextWithAbort = {
+        ...mockContext,
+        abortSignal: mockAbortSignal,
+      };
+
+      await stepDefinition.handler(contextWithAbort as any);
+
+      expect(mockInvokeAttackDiscoveryGraphWithAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          abortSignal: mockAbortSignal,
+        })
+      );
+    });
+
+    it('passes undefined abortSignal when not provided', async () => {
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: [],
+        replacements: {},
+      });
+
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockInvokeAttackDiscoveryGraphWithAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          abortSignal: undefined,
+        })
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns error when graph invocation fails', async () => {
+      const graphError = new Error('Graph invocation failed');
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockRejectedValue(graphError);
+
+      const result = await stepDefinition.handler(mockContext as any);
+
+      expect(result.error).toBeDefined();
+    });
+
+    it('returns error message when graph invocation fails', async () => {
+      const graphError = new Error('Graph invocation failed');
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockRejectedValue(graphError);
+
+      const result = await stepDefinition.handler(mockContext as any);
+
+      expect(result.error?.message).toBe('Graph invocation failed');
+    });
+
+    it('logs error when graph invocation fails', async () => {
+      const graphError = new Error('Graph invocation failed');
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockRejectedValue(graphError);
+
+      await stepDefinition.handler(mockContext as any);
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Generation failed: Graph invocation failed',
+        graphError
+      );
+    });
+  });
+
+  describe('field conversion', () => {
+    it('converts all fields from camelCase to snake_case', async () => {
+      const discoveryWithAllFields: AttackDiscovery = {
+        alertIds: ['alert-1', 'alert-2', 'alert-3'],
+        detailsMarkdown: 'Detailed markdown content',
+        entitySummaryMarkdown: 'Entity summary content',
+        id: 'discovery-123',
+        mitreAttackTactics: ['Initial Access', 'Persistence', 'Privilege Escalation'],
+        summaryMarkdown: 'Summary content',
+        timestamp: '2025-01-09T12:00:00.000Z',
+        title: 'Complex Attack Pattern',
+      };
+
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: [discoveryWithAllFields],
+        replacements: {},
+      });
+
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      if (!output.attack_discoveries) throw new Error('Expected attack_discoveries to be defined');
+
+      expect(output.attack_discoveries[0]).toEqual({
+        alert_ids: ['alert-1', 'alert-2', 'alert-3'],
+        details_markdown: 'Detailed markdown content',
+        entity_summary_markdown: 'Entity summary content',
+        id: 'discovery-123',
+        mitre_attack_tactics: ['Initial Access', 'Persistence', 'Privilege Escalation'],
+        summary_markdown: 'Summary content',
+        timestamp: '2025-01-09T12:00:00.000Z',
+        title: 'Complex Attack Pattern',
+      });
+    });
+  });
+
+  describe('multiple discoveries', () => {
+    it('returns correct number of discoveries', async () => {
+      const multipleDiscoveries: AttackDiscovery[] = [
+        {
+          alertIds: ['alert-1'],
+          detailsMarkdown: 'Details 1',
+          summaryMarkdown: 'Summary 1',
+          title: 'Attack 1',
+        },
+        {
+          alertIds: ['alert-2'],
+          detailsMarkdown: 'Details 2',
+          summaryMarkdown: 'Summary 2',
+          title: 'Attack 2',
+        },
+        {
+          alertIds: ['alert-3'],
+          detailsMarkdown: 'Details 3',
+          summaryMarkdown: 'Summary 3',
+          title: 'Attack 3',
+        },
+      ];
+
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: multipleDiscoveries,
+        replacements: {},
+      });
+
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      if (!output.attack_discoveries) throw new Error('Expected attack_discoveries to be defined');
+
+      expect(output.attack_discoveries).toHaveLength(3);
+    });
+
+    it('converts first discovery alert_ids correctly', async () => {
+      const multipleDiscoveries: AttackDiscovery[] = [
+        {
+          alertIds: ['alert-1'],
+          detailsMarkdown: 'Details 1',
+          summaryMarkdown: 'Summary 1',
+          title: 'Attack 1',
+        },
+        {
+          alertIds: ['alert-2'],
+          detailsMarkdown: 'Details 2',
+          summaryMarkdown: 'Summary 2',
+          title: 'Attack 2',
+        },
+        {
+          alertIds: ['alert-3'],
+          detailsMarkdown: 'Details 3',
+          summaryMarkdown: 'Summary 3',
+          title: 'Attack 3',
+        },
+      ];
+
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: multipleDiscoveries,
+        replacements: {},
+      });
+
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      if (!output.attack_discoveries) throw new Error('Expected attack_discoveries to be defined');
+
+      expect(output.attack_discoveries[0].alert_ids).toEqual(['alert-1']);
+    });
+
+    it('converts second discovery alert_ids correctly', async () => {
+      const multipleDiscoveries: AttackDiscovery[] = [
+        {
+          alertIds: ['alert-1'],
+          detailsMarkdown: 'Details 1',
+          summaryMarkdown: 'Summary 1',
+          title: 'Attack 1',
+        },
+        {
+          alertIds: ['alert-2'],
+          detailsMarkdown: 'Details 2',
+          summaryMarkdown: 'Summary 2',
+          title: 'Attack 2',
+        },
+        {
+          alertIds: ['alert-3'],
+          detailsMarkdown: 'Details 3',
+          summaryMarkdown: 'Summary 3',
+          title: 'Attack 3',
+        },
+      ];
+
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: multipleDiscoveries,
+        replacements: {},
+      });
+
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      if (!output.attack_discoveries) throw new Error('Expected attack_discoveries to be defined');
+
+      expect(output.attack_discoveries[1].alert_ids).toEqual(['alert-2']);
+    });
+
+    it('converts third discovery alert_ids correctly', async () => {
+      const multipleDiscoveries: AttackDiscovery[] = [
+        {
+          alertIds: ['alert-1'],
+          detailsMarkdown: 'Details 1',
+          summaryMarkdown: 'Summary 1',
+          title: 'Attack 1',
+        },
+        {
+          alertIds: ['alert-2'],
+          detailsMarkdown: 'Details 2',
+          summaryMarkdown: 'Summary 2',
+          title: 'Attack 2',
+        },
+        {
+          alertIds: ['alert-3'],
+          detailsMarkdown: 'Details 3',
+          summaryMarkdown: 'Summary 3',
+          title: 'Attack 3',
+        },
+      ];
+
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: multipleDiscoveries,
+        replacements: {},
+      });
+
+      const result = await stepDefinition.handler(mockContext as any);
+      const output = getOutputOrThrow(result);
+
+      if (!output.attack_discoveries) throw new Error('Expected attack_discoveries to be defined');
+
+      expect(output.attack_discoveries[2].alert_ids).toEqual(['alert-3']);
+    });
+  });
+
+  describe('step metadata', () => {
+    it('has correct step type ID', () => {
+      expect(stepDefinition.id).toBe(GenerateStepTypeId);
+    });
+
+    it('has attack-discovery.generate as step type ID', () => {
+      expect(GenerateStepTypeId).toBe('attack-discovery.generate');
+    });
+  });
+
+  describe('connector resolution when action_type_id is missing', () => {
+    const inputWithoutActionTypeId = {
+      ...defaultInput,
+      api_config: {
+        connector_id: '.anthropic-claude-4.6-opus-chat_completion',
+        model: 'test-model',
+        // action_type_id intentionally omitted to simulate EIS connector
+      },
+    };
+
+    it('uses inference.getConnectorById when action_type_id is not provided and inference is available', async () => {
+      const mockGetConnectorById = jest.fn().mockResolvedValue({
+        type: '.inference',
+        connectorId: '.anthropic-claude-4.6-opus-chat_completion',
+        isInferenceEndpoint: true,
+        name: 'Anthropic Claude',
+        config: {},
+        capabilities: {},
+        isPreconfigured: true,
+      });
+
+      const getStartServicesWithInference = jest.fn().mockResolvedValue({
+        coreStart: mockCoreStart,
+        pluginsStart: {
+          actions: {
+            getActionsClientWithRequest: jest.fn().mockResolvedValue(mockActionsClient),
+          },
+          inference: {
+            getClient: jest.fn().mockReturnValue({ chatComplete: jest.fn() }),
+            getConnectorById: mockGetConnectorById,
+          },
+        },
+      });
+
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: [],
+        replacements: {},
+      });
+
+      const stepDefWithInference = getGenerateStepDefinition({
+        connectorTimeout: 60000,
+        getEventLogIndex: mockGetEventLogIndex,
+        getEventLogger: mockGetEventLogger,
+        getStartServices: getStartServicesWithInference,
+        langSmithApiKey: undefined,
+        langSmithProject: undefined,
+        logger: mockLogger,
+      });
+
+      const context = { ...mockContext, input: inputWithoutActionTypeId };
+      await stepDefWithInference.handler(context as any);
+
+      expect(mockGetConnectorById).toHaveBeenCalledWith(
+        '.anthropic-claude-4.6-opus-chat_completion',
+        expect.any(Object)
+      );
+    });
+
+    it('passes resolved actionTypeId from inference connector to the graph', async () => {
+      const mockGetConnectorById = jest.fn().mockResolvedValue({
+        type: '.inference',
+        connectorId: '.anthropic-claude-4.6-opus-chat_completion',
+        isInferenceEndpoint: true,
+        name: 'Anthropic Claude',
+        config: {},
+        capabilities: {},
+        isPreconfigured: true,
+      });
+
+      const getStartServicesWithInference = jest.fn().mockResolvedValue({
+        coreStart: mockCoreStart,
+        pluginsStart: {
+          actions: {
+            getActionsClientWithRequest: jest.fn().mockResolvedValue(mockActionsClient),
+          },
+          inference: {
+            getClient: jest.fn().mockReturnValue({ chatComplete: jest.fn() }),
+            getConnectorById: mockGetConnectorById,
+          },
+        },
+      });
+
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: [],
+        replacements: {},
+      });
+
+      const stepDefWithInference = getGenerateStepDefinition({
+        connectorTimeout: 60000,
+        getEventLogIndex: mockGetEventLogIndex,
+        getEventLogger: mockGetEventLogger,
+        getStartServices: getStartServicesWithInference,
+        langSmithApiKey: undefined,
+        langSmithProject: undefined,
+        logger: mockLogger,
+      });
+
+      const context = { ...mockContext, input: inputWithoutActionTypeId };
+      await stepDefWithInference.handler(context as any);
+
+      expect(mockInvokeAttackDiscoveryGraphWithAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiConfig: expect.objectContaining({
+            action_type_id: '.inference',
+          }),
+        })
+      );
+    });
+
+    it('falls back to resolveConnectorDetails when inference plugin is not available', async () => {
+      const mockActionsClientWithGet = {
+        ...mockActionsClient,
+        get: jest.fn().mockResolvedValue({
+          actionTypeId: '.gen-ai',
+          name: 'OpenAI Connector',
+        }),
+      };
+
+      const getStartServicesWithoutInference = jest.fn().mockResolvedValue({
+        coreStart: mockCoreStart,
+        pluginsStart: {
+          actions: {
+            getActionsClientWithRequest: jest.fn().mockResolvedValue(mockActionsClientWithGet),
+          },
+          // inference intentionally omitted
+        },
+      });
+
+      mockInvokeAttackDiscoveryGraphWithAlerts.mockResolvedValue({
+        discoveries: [],
+        replacements: {},
+      });
+
+      const stepDefWithoutInference = getGenerateStepDefinition({
+        connectorTimeout: 60000,
+        getEventLogIndex: mockGetEventLogIndex,
+        getEventLogger: mockGetEventLogger,
+        getStartServices: getStartServicesWithoutInference,
+        langSmithApiKey: undefined,
+        langSmithProject: undefined,
+        logger: mockLogger,
+      });
+
+      const context = { ...mockContext, input: inputWithoutActionTypeId };
+      await stepDefWithoutInference.handler(context as any);
+
+      expect(mockActionsClientWithGet.get).toHaveBeenCalledWith({
+        id: '.anthropic-claude-4.6-opus-chat_completion',
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getGenerateStepDefinition } from './generate_step/get_generate_step_definition';

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step/get_generate_step_definition.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step/get_generate_step_definition.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import type { CoreStart } from '@kbn/core/server';
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+
+import { GenerateStepCommonDefinition } from '../../../../common/step_types/generate_step';
+import type { DiscoveriesPluginStartDeps } from '../../../types';
+import { resolveConnectorDetails } from '../../helpers/resolve_connector_details';
+import { invokeGenerationGraph } from './helpers/invoke_generation_graph';
+import { transformDiscoveriesOutput } from './helpers/transform_discoveries_output';
+
+/**
+ * Server-side implementation of the generate step.
+ * Generates Attack Discoveries from pre-retrieved alerts.
+ */
+export const getGenerateStepDefinition = ({
+  connectorTimeout,
+  getEventLogIndex: _getEventLogIndex,
+  getEventLogger: _getEventLogger,
+  getStartServices,
+  langSmithApiKey,
+  langSmithProject,
+  logger,
+}: {
+  connectorTimeout: number;
+  getEventLogIndex: () => Promise<string>;
+  getEventLogger: () => Promise<unknown>;
+  getStartServices: () => Promise<{
+    coreStart: CoreStart;
+    pluginsStart: DiscoveriesPluginStartDeps;
+  }>;
+  langSmithApiKey?: string;
+  langSmithProject?: string;
+  logger: Logger;
+}) =>
+  createServerStepDefinition({
+    ...GenerateStepCommonDefinition,
+    handler: async (context) => {
+      let executionUuid: string | undefined;
+
+      try {
+        const workflowContext = context.contextManager.getContext();
+
+        const {
+          additional_context: additionalContext,
+          api_config: apiConfig,
+          replacements,
+          size,
+        } = context.input;
+        const alerts = context.input.alerts ?? [];
+
+        context.logger.info(
+          `Starting attack discovery generation from ${alerts.length} pre-retrieved alerts`
+        );
+
+        const { coreStart, pluginsStart } = await getStartServices();
+        const request = context.contextManager.getFakeRequest();
+        executionUuid = workflowContext.execution.id;
+
+        const actionsClient = await pluginsStart.actions.getActionsClientWithRequest(request);
+        const savedObjectsClient = coreStart.savedObjects.getScopedClient(request);
+        const esClient = coreStart.elasticsearch.client.asScoped(request).asCurrentUser;
+        const inferenceClient = pluginsStart.inference?.getClient({ request });
+
+        const parsedApiConfig = apiConfig as {
+          action_type_id?: string;
+          connector_id: string;
+          model?: string;
+        };
+
+        const { actionTypeId: resolvedActionTypeId } = await resolveConnectorDetails({
+          actionsClient,
+          actionTypeId: parsedApiConfig.action_type_id,
+          connectorId: parsedApiConfig.connector_id,
+          connectorName: 'unused',
+          inference: pluginsStart.inference,
+          logger,
+          request,
+        });
+
+        const resolvedApiConfig = {
+          action_type_id: resolvedActionTypeId,
+          connector_id: parsedApiConfig.connector_id,
+          ...(parsedApiConfig.model != null ? { model: parsedApiConfig.model } : {}),
+        };
+
+        if (alerts.length === 0) {
+          context.logger.info(
+            `Skipping graph execution because 0 alerts were provided (execution: ${executionUuid})`
+          );
+
+          return {
+            output: {
+              attack_discoveries: null,
+              execution_uuid: executionUuid,
+              replacements: replacements ?? {},
+            },
+          };
+        }
+
+        const result = await invokeGenerationGraph({
+          abortSignal: context.abortSignal,
+          actionsClient,
+          additionalContext,
+          apiConfig: resolvedApiConfig,
+          connectorTimeout,
+          esClient,
+          inferenceClient,
+          langSmithApiKey,
+          langSmithProject,
+          logger,
+          replacements,
+          savedObjectsClient,
+          size,
+          sourceAlerts: alerts,
+        });
+
+        context.logger.info(
+          `Attack Discovery generation completed: ${result.discoveries?.length ?? 0} discoveries`
+        );
+
+        const attackDiscoveriesOutput = transformDiscoveriesOutput(result.discoveries, {
+          executionUuid,
+        });
+
+        return {
+          output: {
+            attack_discoveries: attackDiscoveriesOutput,
+            execution_uuid: executionUuid,
+            replacements: result.replacements,
+          },
+        };
+      } catch (error) {
+        context.logger.error(
+          `Generation failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          error
+        );
+
+        return {
+          error: new Error(
+            error instanceof Error ? error.message : 'Failed to generate discoveries'
+          ),
+        };
+      }
+    },
+  });

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step/helpers/authenticate_workflow_user.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step/helpers/authenticate_workflow_user.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AuthenticatedUser, CoreStart, KibanaRequest } from '@kbn/core/server';
+
+export const authenticateWorkflowUser = async ({
+  coreStart,
+  request,
+}: {
+  coreStart: CoreStart;
+  request: KibanaRequest;
+}): Promise<AuthenticatedUser> => {
+  const authenticationInfo = await coreStart.elasticsearch.client
+    .asScoped(request)
+    .asCurrentUser.security.authenticate();
+
+  return {
+    ...(authenticationInfo as unknown as AuthenticatedUser),
+    authentication_provider: { name: 'workflows', type: 'workflows' },
+    elastic_cloud_user: false,
+  };
+};

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step/helpers/handle_generation_error.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step/helpers/handle_generation_error.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AuthenticatedUser, Logger } from '@kbn/core/server';
+import {
+  ATTACK_DISCOVERY_EVENT_LOG_ACTION_GENERATION_FAILED,
+  writeAttackDiscoveryEvent,
+} from '@kbn/discoveries/impl/attack_discovery/persistence/event_logging';
+import { getDurationNanoseconds } from '@kbn/discoveries/impl/lib/persistence';
+import type { IEventLogger } from '@kbn/event-log-plugin/server';
+
+export const handleGenerationError = async ({
+  authenticatedUser,
+  endTime,
+  error,
+  eventLogger,
+  eventLogIndex,
+  executionUuid,
+  logger,
+  spaceId,
+  startTime,
+  workflowId,
+  workflowRunId,
+  stepInput,
+}: {
+  authenticatedUser: AuthenticatedUser | undefined;
+  endTime: Date;
+  error: unknown;
+  eventLogger: IEventLogger | undefined;
+  eventLogIndex: string | undefined;
+  executionUuid: string | undefined;
+  logger: Logger;
+  spaceId: string | undefined;
+  startTime: Date;
+  workflowId?: string;
+  workflowRunId?: string;
+  stepInput: {
+    alerts?: unknown;
+    api_config?: unknown;
+  };
+}): Promise<void> => {
+  if (!executionUuid || !authenticatedUser || !spaceId || !eventLogger || !eventLogIndex) {
+    return;
+  }
+
+  const apiConfig = stepInput.api_config as { connector_id?: string } | undefined;
+  const connectorId = apiConfig?.connector_id;
+
+  if (!connectorId) {
+    return;
+  }
+
+  try {
+    await writeAttackDiscoveryEvent({
+      action: ATTACK_DISCOVERY_EVENT_LOG_ACTION_GENERATION_FAILED,
+      alertsContextCount: Array.isArray(stepInput.alerts) ? stepInput.alerts.length : undefined,
+      authenticatedUser,
+      connectorId,
+      dataClient: null,
+      duration: getDurationNanoseconds({ end: endTime, start: startTime }),
+      end: endTime,
+      eventLogger,
+      eventLogIndex,
+      executionUuid,
+      message: `Attack discovery generation ${executionUuid} failed`,
+      outcome: 'failure',
+      reason: error instanceof Error ? error.message : 'Unknown error',
+      spaceId,
+      workflowId,
+      workflowRunId,
+    });
+  } catch (loggingError) {
+    logger.error(
+      `Failed to log generation-failed event: ${
+        loggingError instanceof Error ? loggingError.message : 'Unknown error'
+      }`
+    );
+  }
+};

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step/helpers/invoke_generation_graph.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step/helpers/invoke_generation_graph.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PublicMethodsOf } from '@kbn/utility-types';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
+import type { ElasticsearchClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
+import { alertsToDocuments } from '@kbn/discoveries/impl/lib/types';
+
+import type { Replacements } from '@kbn/elastic-assistant-common';
+import type { InferenceClient } from '@kbn/inference-common';
+import { getLlmType } from '@kbn/discoveries/impl/lib/helpers/get_llm_type';
+import { invokeAttackDiscoveryGraphWithAlerts } from '@kbn/discoveries/impl/attack_discovery/graphs/invoke_graph_with_alerts';
+import { getAttackDiscoveryPrompts } from '../../../../lib/attack_discovery/prompts';
+
+export const invokeGenerationGraph = async ({
+  abortSignal,
+  actionsClient,
+  additionalContext,
+  apiConfig,
+  connectorTimeout,
+  esClient,
+  inferenceClient,
+  langSmithApiKey,
+  langSmithProject,
+  logger,
+  replacements,
+  savedObjectsClient,
+  size,
+  sourceAlerts,
+}: {
+  abortSignal?: AbortSignal;
+  actionsClient: PublicMethodsOf<ActionsClient>;
+  additionalContext?: string;
+  apiConfig: {
+    action_type_id: string;
+    connector_id: string;
+    model?: string;
+  };
+  connectorTimeout: number;
+  esClient: ElasticsearchClient;
+  inferenceClient?: InferenceClient;
+  langSmithApiKey?: string;
+  langSmithProject?: string;
+  logger: Logger;
+  replacements?: Replacements;
+  savedObjectsClient: SavedObjectsClientContract;
+  size?: number;
+  sourceAlerts: string[];
+}) => {
+  const anonymizedDocuments = alertsToDocuments(sourceAlerts);
+
+  const prompts = await getAttackDiscoveryPrompts({
+    connectorId: apiConfig.connector_id,
+    model: apiConfig.model,
+    provider: getLlmType(apiConfig.action_type_id),
+    savedObjectsClient,
+  });
+
+  return await invokeAttackDiscoveryGraphWithAlerts({
+    abortSignal,
+    actionsClient,
+    additionalContext,
+    alerts: anonymizedDocuments,
+    apiConfig,
+    connectorTimeout,
+    esClient,
+    inferenceClient,
+    langSmithApiKey,
+    langSmithProject,
+    logger,
+    prompts,
+    replacements,
+    size,
+  });
+};

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step/helpers/transform_discoveries_output.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step/helpers/transform_discoveries_output.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AttackDiscovery } from '@kbn/elastic-assistant-common';
+
+interface AttackDiscoveryApiOutput {
+  alert_ids: string[];
+  details_markdown: string;
+  entity_summary_markdown?: string;
+  id?: string;
+  mitre_attack_tactics?: string[];
+  summary_markdown: string;
+  timestamp?: string;
+  title: string;
+}
+
+export const transformDiscoveriesOutput = (
+  discoveries: AttackDiscovery[] | null | undefined,
+  {
+    executionUuid,
+  }: {
+    executionUuid: string;
+  }
+): AttackDiscoveryApiOutput[] | null => {
+  if (discoveries == null) {
+    return null;
+  }
+
+  return discoveries.map((discovery, index) => ({
+    alert_ids: discovery.alertIds ?? [],
+    details_markdown: discovery.detailsMarkdown ?? '',
+    entity_summary_markdown: discovery.entitySummaryMarkdown,
+    // If upstream did not provide an id, generate a stable, per-execution fallback id
+    // so validation can persist distinct discoveries even when `alert_ids` is empty.
+    id: discovery.id ?? `${executionUuid}-${index}`,
+    mitre_attack_tactics: discovery.mitreAttackTactics,
+    summary_markdown: discovery.summaryMarkdown ?? '',
+    timestamp: discovery.timestamp,
+    title: discovery.title ?? '',
+  }));
+};

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/generate_step/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getGenerateStepDefinition } from './get_generate_step_definition';

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/persist_discoveries_step/get_persist_discoveries_step_definition.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/persist_discoveries_step/get_persist_discoveries_step_definition.test.ts
@@ -1,0 +1,396 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AuthenticatedUser, Logger } from '@kbn/core/server';
+import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
+
+import { getPersistDiscoveriesStepDefinition } from './get_persist_discoveries_step_definition';
+import { resolveConnectorDetails } from '../../helpers/resolve_connector_details';
+import { validateAttackDiscoveries } from '../../../routes/post/validate/helpers/validate_attack_discoveries';
+import { authenticateAndGetSpace } from '../default_validation_step/helpers/authenticate_and_get_space';
+
+jest.mock('../../helpers/resolve_connector_details', () => ({
+  resolveConnectorDetails: jest.fn(),
+}));
+
+jest.mock('../../../routes/post/validate/helpers/validate_attack_discoveries', () => ({
+  validateAttackDiscoveries: jest.fn(),
+}));
+
+jest.mock('../default_validation_step/helpers/authenticate_and_get_space', () => ({
+  authenticateAndGetSpace: jest.fn(),
+}));
+
+const mockResolveConnectorDetails = resolveConnectorDetails as jest.MockedFunction<
+  typeof resolveConnectorDetails
+>;
+const mockValidateAttackDiscoveries = validateAttackDiscoveries as jest.MockedFunction<
+  typeof validateAttackDiscoveries
+>;
+const mockAuthenticateAndGetSpace = authenticateAndGetSpace as jest.MockedFunction<
+  typeof authenticateAndGetSpace
+>;
+
+describe('getPersistDiscoveriesStepDefinition', () => {
+  const mockLogger = {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  } as unknown as Logger;
+
+  const mockAdhocAttackDiscoveryDataClient = {
+    getReader: jest.fn(),
+    getWriter: jest.fn(),
+    indexNameWithNamespace: jest.fn(),
+  } as unknown as IRuleDataClient;
+
+  const mockActionsClient = { get: jest.fn() };
+
+  const mockGetStartServices = jest.fn().mockResolvedValue({
+    coreStart: {
+      elasticsearch: {
+        client: {
+          asInternalUser: {
+            indices: {
+              refresh: jest.fn(),
+            },
+          },
+        },
+      },
+    },
+    pluginsStart: {
+      actions: {
+        getActionsClientWithRequest: jest.fn().mockResolvedValue(mockActionsClient),
+      },
+    },
+  });
+
+  const mockAuthenticatedUser = {
+    profile_uid: 'profile-1',
+    username: 'test-user',
+  } as unknown as AuthenticatedUser;
+
+  const mockEsClient = {};
+
+  const mockContext = {
+    contextManager: {
+      getContext: jest.fn().mockReturnValue({
+        execution: { id: 'workflow-run-1' },
+        workflow: { id: 'workflow-1' },
+      }),
+      getFakeRequest: jest.fn().mockReturnValue({
+        headers: {},
+      }),
+    },
+    input: {
+      alerts_context_count: 10,
+      anonymized_alerts: [],
+      api_config: { action_type_id: '.gen-ai', connector_id: 'connector-1' },
+      attack_discoveries: [
+        {
+          alert_ids: ['alert-1'],
+          details_markdown: 'Details',
+          entity_summary_markdown: 'Entity',
+          mitre_attack_tactics: ['Initial Access'],
+          summary_markdown: 'Summary',
+          title: 'Test Discovery',
+        },
+      ],
+      connector_name: 'Test Connector',
+      enable_field_rendering: true,
+      generation_uuid: 'generation-1',
+      replacements: {},
+      with_replacements: false,
+    },
+    logger: {
+      error: jest.fn(),
+      info: jest.fn(),
+    },
+  };
+
+  const getOutputOrThrow = <T>(result: { output?: T }): T => {
+    if (!result.output) {
+      throw new Error('Expected result.output to be defined');
+    }
+
+    return result.output;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockResolveConnectorDetails.mockResolvedValue({
+      actionTypeId: '.gen-ai',
+      connectorName: 'Test Connector',
+    });
+
+    mockAuthenticateAndGetSpace.mockResolvedValue({
+      authenticationInfo: {},
+      authenticatedUser: mockAuthenticatedUser,
+      esClient: mockEsClient,
+      spaceId: 'default',
+    } as unknown as Awaited<ReturnType<typeof authenticateAndGetSpace>>);
+  });
+
+  describe('step definition metadata', () => {
+    it('has the correct id', () => {
+      const stepDefinition = getPersistDiscoveriesStepDefinition({
+        adhocAttackDiscoveryDataClient: mockAdhocAttackDiscoveryDataClient,
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      expect(stepDefinition.id).toBe('attack-discovery.persistDiscoveries');
+    });
+  });
+
+  describe('when persistence succeeds', () => {
+    const persistedDiscoveries = [
+      {
+        alert_ids: ['alert-1'],
+        connector_id: 'connector-1',
+        connector_name: 'Test Connector',
+        details_markdown: 'Details',
+        generation_uuid: 'generation-1',
+        id: 'discovery-1',
+        summary_markdown: 'Summary',
+        timestamp: '2025-01-01T00:00:00Z',
+        title: 'Test Discovery',
+      },
+    ];
+
+    beforeEach(() => {
+      mockValidateAttackDiscoveries.mockResolvedValue({
+        duplicates_dropped_count: 0,
+        validated_discoveries: persistedDiscoveries,
+      });
+    });
+
+    it('returns persisted discoveries', async () => {
+      const stepDefinition = getPersistDiscoveriesStepDefinition({
+        adhocAttackDiscoveryDataClient: mockAdhocAttackDiscoveryDataClient,
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      const result = await stepDefinition.handler(mockContext as never);
+
+      const output = getOutputOrThrow(result);
+
+      expect(output).toEqual({
+        duplicates_dropped_count: 0,
+        persisted_discoveries: persistedDiscoveries,
+      });
+    });
+
+    it('calls validateAttackDiscoveries with the correct arguments', async () => {
+      const stepDefinition = getPersistDiscoveriesStepDefinition({
+        adhocAttackDiscoveryDataClient: mockAdhocAttackDiscoveryDataClient,
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      await stepDefinition.handler(mockContext as never);
+
+      expect(mockValidateAttackDiscoveries).toHaveBeenCalledWith({
+        adhocAttackDiscoveryDataClient: mockAdhocAttackDiscoveryDataClient,
+        authenticatedUser: mockAuthenticatedUser,
+        logger: expect.objectContaining({
+          debug: expect.any(Function),
+          error: expect.any(Function),
+          fatal: expect.any(Function),
+          get: expect.any(Function),
+          info: expect.any(Function),
+          isLevelEnabled: expect.any(Function),
+          log: expect.any(Function),
+          trace: expect.any(Function),
+          warn: expect.any(Function),
+        }),
+        spaceId: 'default',
+        validateRequestBody: {
+          alerts_context_count: 10,
+          anonymized_alerts: [],
+          api_config: { action_type_id: '.gen-ai', connector_id: 'connector-1' },
+          attack_discoveries: mockContext.input.attack_discoveries,
+          connector_name: 'Test Connector',
+          enable_field_rendering: true,
+          generation_uuid: 'generation-1',
+          replacements: {},
+          with_replacements: false,
+        },
+      });
+    });
+
+    it('logs a success message', async () => {
+      const stepDefinition = getPersistDiscoveriesStepDefinition({
+        adhocAttackDiscoveryDataClient: mockAdhocAttackDiscoveryDataClient,
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      await stepDefinition.handler(mockContext as never);
+
+      expect(mockContext.logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Persisting 1 attack discoveries')
+      );
+    });
+  });
+
+  describe('when no discoveries are provided', () => {
+    it('returns empty persisted_discoveries without calling validateAttackDiscoveries', async () => {
+      const contextWithNoDiscoveries = {
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          attack_discoveries: [],
+        },
+      };
+
+      const stepDefinition = getPersistDiscoveriesStepDefinition({
+        adhocAttackDiscoveryDataClient: mockAdhocAttackDiscoveryDataClient,
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      const result = await stepDefinition.handler(contextWithNoDiscoveries as never);
+
+      const output = getOutputOrThrow(result);
+
+      expect(output).toEqual({
+        duplicates_dropped_count: 0,
+        persisted_discoveries: [],
+      });
+      expect(mockValidateAttackDiscoveries).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when authentication fails', () => {
+    beforeEach(() => {
+      mockAuthenticateAndGetSpace.mockResolvedValue({
+        authenticationInfo: {},
+        authenticatedUser: undefined,
+        esClient: mockEsClient,
+        spaceId: 'default',
+      } as unknown as Awaited<ReturnType<typeof authenticateAndGetSpace>>);
+    });
+
+    it('returns an error', async () => {
+      const stepDefinition = getPersistDiscoveriesStepDefinition({
+        adhocAttackDiscoveryDataClient: mockAdhocAttackDiscoveryDataClient,
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      await stepDefinition.handler(mockContext as never);
+
+      expect(mockContext.logger.error).toHaveBeenCalledWith(
+        'Failed to persist discoveries',
+        expect.any(Error)
+      );
+    });
+  });
+
+  describe('when connector_id is missing from api_config', () => {
+    beforeEach(() => {
+      mockAuthenticateAndGetSpace.mockResolvedValue({
+        authenticationInfo: {},
+        authenticatedUser: mockAuthenticatedUser,
+        esClient: mockEsClient,
+        spaceId: 'default',
+      } as unknown as Awaited<ReturnType<typeof authenticateAndGetSpace>>);
+    });
+
+    it('returns an error about missing connector_id', async () => {
+      const contextWithoutConnectorId = {
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          api_config: {},
+        },
+      };
+
+      const stepDefinition = getPersistDiscoveriesStepDefinition({
+        adhocAttackDiscoveryDataClient: mockAdhocAttackDiscoveryDataClient,
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      await stepDefinition.handler(contextWithoutConnectorId as never);
+
+      expect(mockContext.logger.error).toHaveBeenCalledWith(
+        'Failed to persist discoveries',
+        expect.objectContaining({
+          message: 'Missing connector_id in api_config',
+        })
+      );
+    });
+  });
+
+  describe('when persistence fails with an error', () => {
+    const persistenceError = new Error('Bulk insert failed');
+
+    beforeEach(() => {
+      mockValidateAttackDiscoveries.mockRejectedValue(persistenceError);
+    });
+
+    it('logs the error to the context logger', async () => {
+      const stepDefinition = getPersistDiscoveriesStepDefinition({
+        adhocAttackDiscoveryDataClient: mockAdhocAttackDiscoveryDataClient,
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      await stepDefinition.handler(mockContext as never);
+
+      expect(mockContext.logger.error).toHaveBeenCalledWith(
+        'Failed to persist discoveries',
+        expect.any(Error)
+      );
+    });
+
+    it('returns an error object', async () => {
+      const stepDefinition = getPersistDiscoveriesStepDefinition({
+        adhocAttackDiscoveryDataClient: mockAdhocAttackDiscoveryDataClient,
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      const result = await stepDefinition.handler(mockContext as never);
+
+      expect(result).toHaveProperty('error');
+    });
+  });
+
+  describe('when spaceId is missing', () => {
+    beforeEach(() => {
+      mockAuthenticateAndGetSpace.mockResolvedValue({
+        authenticationInfo: {},
+        authenticatedUser: mockAuthenticatedUser,
+        esClient: mockEsClient,
+        spaceId: undefined,
+      } as unknown as Awaited<ReturnType<typeof authenticateAndGetSpace>>);
+    });
+
+    it('returns an error about missing space id', async () => {
+      const stepDefinition = getPersistDiscoveriesStepDefinition({
+        adhocAttackDiscoveryDataClient: mockAdhocAttackDiscoveryDataClient,
+        getStartServices: mockGetStartServices,
+        logger: mockLogger,
+      });
+
+      await stepDefinition.handler(mockContext as never);
+
+      expect(mockContext.logger.error).toHaveBeenCalledWith(
+        'Failed to persist discoveries',
+        expect.objectContaining({
+          message: 'Failed to resolve space id',
+        })
+      );
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/persist_discoveries_step/get_persist_discoveries_step_definition.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/persist_discoveries_step/get_persist_discoveries_step_definition.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import type { Logger } from '@kbn/core/server';
+import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
+import type { CoreStart } from '@kbn/core/server';
+
+import { createTracedLogger } from '@kbn/discoveries/impl/lib/create_traced_logger';
+import type { DiscoveriesPluginStartDeps } from '../../../types';
+import { resolveConnectorDetails } from '../../helpers/resolve_connector_details';
+import { validateAttackDiscoveries } from '../../../routes/post/validate/helpers/validate_attack_discoveries';
+import { PersistDiscoveriesStepCommonDefinition } from '../../../../common/step_types/persist_discoveries_step';
+import { authenticateAndGetSpace } from '../default_validation_step/helpers/authenticate_and_get_space';
+
+export const getPersistDiscoveriesStepDefinition = ({
+  adhocAttackDiscoveryDataClient,
+  getStartServices,
+  logger,
+}: {
+  adhocAttackDiscoveryDataClient: IRuleDataClient;
+  getStartServices: () => Promise<{
+    coreStart: CoreStart;
+    pluginsStart: DiscoveriesPluginStartDeps;
+  }>;
+  logger: Logger;
+}) =>
+  createServerStepDefinition({
+    ...PersistDiscoveriesStepCommonDefinition,
+    handler: async (context) => {
+      try {
+        const {
+          alerts_context_count: alertsContextCount,
+          anonymized_alerts: anonymizedAlerts,
+          api_config: apiConfig,
+          attack_discoveries: attackDiscoveries,
+          connector_name: connectorName,
+          enable_field_rendering: enableFieldRendering = true,
+          generation_uuid: generationUuid,
+          replacements,
+          with_replacements: withReplacements = false,
+        } = context.input;
+
+        const tracedLogger = createTracedLogger(logger, generationUuid);
+
+        tracedLogger.info('[PERSIST] Handler starting...');
+
+        if (attackDiscoveries.length === 0) {
+          tracedLogger.info('[PERSIST] No discoveries to persist');
+
+          return {
+            output: {
+              duplicates_dropped_count: 0,
+              persisted_discoveries: [],
+            },
+          };
+        }
+
+        context.logger.info(
+          `Persisting ${attackDiscoveries.length} attack discoveries (generation: ${generationUuid})`
+        );
+
+        const { coreStart, pluginsStart } = await getStartServices();
+        const request = context.contextManager.getFakeRequest();
+
+        const { authenticatedUser, spaceId } = await authenticateAndGetSpace({
+          coreStart,
+          pluginsStart,
+          request,
+        });
+
+        if (!authenticatedUser) {
+          throw new Error(
+            'Persist discoveries step failed to resolve authenticated user. Check service account or API key configuration for scheduled runs.'
+          );
+        }
+
+        const parsedApiConfig = apiConfig as { connector_id?: string } | undefined;
+        const connectorId = parsedApiConfig?.connector_id;
+
+        if (!connectorId) {
+          throw new Error('Missing connector_id in api_config');
+        }
+
+        if (!spaceId) {
+          throw new Error('Failed to resolve space id');
+        }
+
+        const actionsClient = await pluginsStart.actions.getActionsClientWithRequest(request);
+
+        const { connectorName: resolvedConnectorName } = await resolveConnectorDetails({
+          actionsClient,
+          connectorId,
+          connectorName,
+          inference: pluginsStart.inference,
+          logger,
+          request,
+        });
+
+        const result = await validateAttackDiscoveries({
+          adhocAttackDiscoveryDataClient,
+          authenticatedUser,
+          logger: tracedLogger,
+          spaceId,
+          validateRequestBody: {
+            alerts_context_count: alertsContextCount,
+            anonymized_alerts: anonymizedAlerts,
+            api_config: apiConfig,
+            attack_discoveries: attackDiscoveries,
+            connector_name: resolvedConnectorName,
+            enable_field_rendering: enableFieldRendering,
+            generation_uuid: generationUuid,
+            replacements,
+            with_replacements: withReplacements,
+          },
+        });
+
+        tracedLogger.info(
+          `[PERSIST] Successfully persisted ${
+            result.validated_discoveries?.length ?? 0
+          } discoveries (${result.duplicates_dropped_count} duplicates dropped)`
+        );
+
+        return {
+          output: {
+            duplicates_dropped_count: result.duplicates_dropped_count,
+            persisted_discoveries: result.validated_discoveries,
+          },
+        };
+      } catch (error) {
+        logger.debug(
+          () => `[PERSIST] ERROR: ${error instanceof Error ? error.stack : String(error)}`
+        );
+
+        context.logger.error(
+          'Failed to persist discoveries',
+          error instanceof Error ? error : undefined
+        );
+
+        return {
+          error: new Error(
+            error instanceof Error ? error.message : 'Failed to persist discoveries'
+          ),
+        };
+      }
+    },
+  });

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/persist_discoveries_step/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/persist_discoveries_step/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getPersistDiscoveriesStepDefinition } from './get_persist_discoveries_step_definition';

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/run_step/README.md
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/run_step/README.md
@@ -1,0 +1,128 @@
+# `attack-discovery.run` Workflow Step
+
+The `attack-discovery.run` step is the high-level entry point into the Attack Discovery pipeline. It orchestrates alert retrieval, LLM-based discovery generation, and validation in a single, composable workflow step.
+
+## What it does
+
+When a workflow invokes `attack-discovery.run`, the step:
+
+1. **Resolves the connector** — looks up the `action_type_id` for the given `connector_id` so the generation engine knows which LLM provider to use.
+2. **Builds a workflow config** — maps the step's inputs to the internal `WorkflowConfig` structure, including alert retrieval mode, ES|QL query, pre-retrieved alerts, and validation overrides.
+3. **Runs the pipeline** via `executeGenerationWorkflow` from `@kbn/discoveries`:
+   - **Alert retrieval** — fetches and anonymizes alerts from Elasticsearch (unless `alerts` is provided directly).
+   - **Generation** — sends anonymized alerts to the LLM and parses attack discovery objects.
+   - **Validation** — deduplicates discoveries against previously persisted results.
+4. **Returns the output** — in sync mode, returns discoveries inline; in async mode, returns only `execution_uuid` immediately.
+
+## Why it exists
+
+Before this step, the only way to trigger Attack Discovery was through the internal REST API at `POST /internal/attack_discovery/_generate`. That endpoint works well for the Kibana UI, but it is not composable — it cannot be wired into a larger workflow, it cannot receive alerts from an upstream step, and it cannot be customized without modifying the API itself.
+
+The `attack-discovery.run` step exposes the same underlying pipeline to the Kibana Workflows engine. This means:
+
+- A detection rule workflow can retrieve specific alerts and pass them directly to Attack Discovery.
+- Multiple Attack Discovery runs can be composed into a single workflow (e.g., separate runs per tenant or time window).
+- Custom alert retrieval workflows can feed their results into the step via the `alerts` input.
+- The validation step can be replaced with a custom workflow by setting `validation_workflow_id`.
+
+## Key design decisions
+
+### `alerts` is the primary composability point
+
+When `alerts` is provided (non-empty), the step automatically sets `alert_retrieval_mode` to `provided`, bypassing all retrieval. This is how upstream steps or workflows pass their alert output to Attack Discovery without having to know about retrieval modes:
+
+```yaml
+with:
+  alerts: ${{ steps.my_retrieval_step.output.alerts }}
+  connector_id: ${{ inputs.connector_id }}
+```
+
+### The `replacements` map is never exposed
+
+The anonymization `replacements` map (which maps anonymized tokens back to real entity names) is held in memory during the pipeline but is intentionally excluded from the step output. Exposing it would leak PII/sensitive entity names into workflow state, logs, and any downstream steps.
+
+### Sync vs async mode
+
+| Mode | Behavior | When to use |
+|------|----------|-------------|
+| `sync` (default) | Waits for the full pipeline; returns `attack_discoveries`, `discovery_count`, `alerts_context_count`, `execution_uuid` | When downstream steps need the discoveries |
+| `async` | Fires the pipeline without waiting; returns only `execution_uuid` | When the caller only needs to trigger the run and track it separately |
+
+In async mode, pipeline errors are logged but do not propagate to the workflow — the step always returns successfully with the `execution_uuid`.
+
+### Alert retrieval modes
+
+| Mode | Description |
+|------|-------------|
+| `custom_query` (default) | DSL query against `.alerts-security.alerts-default`; respects `start`, `end`, `size`, `filter` |
+| `provided` | Uses the `alerts` input directly; no Elasticsearch query |
+| `esql` | Runs the ES\|QL query in `esql_query` |
+| `disabled` | Skips retrieval entirely (generation receives no alert context) |
+
+## Implementation files
+
+| File | Purpose |
+|------|---------|
+| [`common/step_types/run_step.ts`](../../../../common/step_types/run_step.ts) | Zod schemas for input/output; `RunStepCommonDefinition` shared between server and UI |
+| [`server/workflows/steps/run_step/get_run_step_definition.ts`](./get_run_step_definition.ts) | Server-side handler; connector resolution, pipeline orchestration, sync/async branching |
+| [`common/step_types/shared_schemas.ts`](../../../../common/step_types/shared_schemas.ts) | Reusable `AttackDiscoverySchema`, `AnonymizedAlertSchema`, `ApiConfigSchema` |
+
+## vs. the internal REST API
+
+The `POST /internal/attack_discovery/_generate` route and the `attack-discovery.run` step call the same underlying function (`executeGenerationWorkflow`), but they serve different callers:
+
+| | `POST /internal/attack_discovery/_generate` | `attack-discovery.run` step |
+|---|---|---|
+| **Caller** | Kibana UI (`useAttackDiscovery` hook) | Kibana Workflows engine |
+| **Trigger** | HTTP request | Workflow execution |
+| **Mode** | Always async (fire-and-forget) | Sync or async |
+| **Composability** | None — standalone endpoint | Full — receives output from upstream steps |
+| **Alert input** | Body parameter or retrieval via config | `alerts` input from upstream steps |
+| **Auth** | Kibana HTTP auth | Workflow execution context |
+
+Use the REST API when building Kibana UI features. Use the workflow step when building automated pipelines.
+
+## Example workflow
+
+The `Attack discovery - Run example` workflow ([`attack_discovery_run_example.workflow.yaml`](../../definitions/attack_discovery_run_example.workflow.yaml)) demonstrates the step with all inputs documented and the `alerts` composability pattern highlighted:
+
+```yaml
+steps:
+  - name: run_attack_discovery
+    type: attack-discovery.run
+    timeout: '10m'
+    with:
+      # Primary composability point: when non-empty, retrieval is skipped.
+      alerts: ${{ inputs.alerts }}
+      connector_id: ${{ inputs.connector_id }}
+      # All other inputs are optional with sensible defaults:
+      alert_retrieval_mode: ${{ inputs.alert_retrieval_mode }}   # default: custom_query
+      mode: ${{ inputs.mode }}                                    # default: sync
+      start: ${{ inputs.start }}
+      end: ${{ inputs.end }}
+      size: ${{ inputs.size }}
+```
+
+The example exposes all inputs as workflow inputs so the same workflow can run standalone (using `custom_query` retrieval) or be called from another workflow that supplies pre-retrieved `alerts`.
+
+## Output shape (sync mode)
+
+```typescript
+{
+  execution_uuid: string;          // Always present
+  attack_discoveries: Array<{      // null if validation failed
+    alert_ids: string[];
+    details_markdown: string;
+    entity_summary_markdown?: string;
+    id?: string;
+    mitre_attack_tactics?: string[];
+    summary_markdown: string;
+    timestamp?: string;
+    title: string;
+  }> | null;
+  discovery_count: number;         // 0 if validation failed
+  alerts_context_count: number;    // 0 if validation failed
+}
+```
+
+In async mode, only `execution_uuid` is returned.

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/run_step/get_run_step_definition.test.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/run_step/get_run_step_definition.test.ts
@@ -1,0 +1,371 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+
+import { getRunStepDefinition } from './get_run_step_definition';
+import { resolveConnectorDetails } from '../../helpers/resolve_connector_details';
+
+const mockExecuteGenerationWorkflow = jest.fn();
+
+jest.mock('@kbn/discoveries/impl/attack_discovery/generation/execute_generation_workflow', () => ({
+  executeGenerationWorkflow: (...args: unknown[]) => mockExecuteGenerationWorkflow(...args),
+}));
+
+jest.mock('../../helpers/resolve_connector_details', () => ({
+  resolveConnectorDetails: jest.fn(),
+}));
+
+jest.mock('uuid', () => ({
+  v4: () => 'test-execution-uuid',
+}));
+
+const mockResolveConnectorDetails = resolveConnectorDetails as jest.MockedFunction<
+  typeof resolveConnectorDetails
+>;
+
+describe('getRunStepDefinition', () => {
+  const mockLogger = {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  } as unknown as Logger;
+
+  const mockActionsClient = { get: jest.fn() };
+
+  const mockGetStartServices = jest.fn().mockResolvedValue({
+    coreStart: {
+      elasticsearch: {
+        client: {
+          asScoped: jest.fn().mockReturnValue({
+            asCurrentUser: {},
+          }),
+        },
+      },
+    },
+    pluginsStart: {
+      actions: {
+        getActionsClientWithRequest: jest.fn().mockResolvedValue(mockActionsClient),
+      },
+    },
+  });
+
+  const mockGetEventLogIndex = jest.fn().mockResolvedValue('.kibana-event-log-*');
+  const mockGetEventLogger = jest.fn().mockResolvedValue({});
+
+  const mockWorkflowInitService = {
+    ensureWorkflowsForSpace: jest.fn(),
+    verifyAndRepairWorkflows: jest.fn(),
+  };
+
+  const baseMockContext = {
+    abortSignal: new AbortController().signal,
+    contextManager: {
+      getContext: jest.fn().mockReturnValue({
+        execution: { id: 'workflow-run-1' },
+        workflow: { id: 'workflow-1', spaceId: 'default' },
+      }),
+      getFakeRequest: jest.fn().mockReturnValue({
+        headers: {},
+      }),
+      getScopedEsClient: jest.fn(),
+      renderInputTemplate: jest.fn(),
+    },
+    logger: {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+    stepId: 'run-step-1',
+    stepType: 'attack-discovery.run',
+  };
+
+  const syncMockContext = {
+    ...baseMockContext,
+    input: {
+      alert_retrieval_mode: 'custom_query' as const,
+      alert_retrieval_workflow_ids: [],
+      connector_id: 'test-connector',
+      mode: 'sync' as const,
+      validation_workflow_id: '',
+    },
+  };
+
+  const asyncMockContext = {
+    ...baseMockContext,
+    input: {
+      alert_retrieval_mode: 'custom_query' as const,
+      alert_retrieval_workflow_ids: [],
+      connector_id: 'test-connector',
+      mode: 'async' as const,
+      validation_workflow_id: '',
+    },
+  };
+
+  const mockSuccessOutcome = {
+    alertRetrievalResult: {
+      alerts: ['alert-1', 'alert-2'],
+      alertsContextCount: 5,
+      anonymizedAlerts: [],
+      apiConfig: { action_type_id: '.gen-ai', connector_id: 'test-connector' },
+      connectorName: 'Test Connector',
+      replacements: { 'uuid-1': 'real-value-1', 'uuid-2': 'real-value-2' },
+      workflowExecutions: [],
+    },
+    generationResult: {
+      alertsContextCount: 5,
+      attackDiscoveries: [
+        {
+          alert_ids: ['alert-1'],
+          details_markdown: 'Details about the attack',
+          entity_summary_markdown: 'Entity summary',
+          mitre_attack_tactics: ['Initial Access'],
+          summary_markdown: 'A summary',
+          title: 'Test Discovery',
+        },
+      ],
+      executionUuid: 'test-execution-uuid',
+      replacements: { 'uuid-1': 'real-value-1', 'uuid-2': 'real-value-2' },
+      workflowId: 'gen-workflow-1',
+      workflowRunId: 'gen-run-1',
+    },
+    outcome: 'validation_succeeded' as const,
+    validationResult: {
+      duplicatesDroppedCount: 0,
+      generatedCount: 1,
+      success: true,
+      workflowId: 'val-workflow-1',
+      workflowRunId: 'val-run-1',
+    },
+  };
+
+  const getStepDefinition = () =>
+    getRunStepDefinition({
+      getEventLogIndex: mockGetEventLogIndex,
+      getEventLogger: mockGetEventLogger,
+      getStartServices: mockGetStartServices,
+      logger: mockLogger,
+      workflowInitService: mockWorkflowInitService,
+    });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockResolveConnectorDetails.mockResolvedValue({
+      actionTypeId: '.gen-ai',
+      connectorName: 'Test Connector',
+    });
+
+    mockExecuteGenerationWorkflow.mockResolvedValue(mockSuccessOutcome);
+  });
+
+  describe('step definition metadata', () => {
+    it('has the correct id', () => {
+      const stepDefinition = getStepDefinition();
+
+      expect(stepDefinition.id).toBe('attack-discovery.run');
+    });
+  });
+
+  describe('connector resolution', () => {
+    it('resolves connector details when only connector_id is provided', async () => {
+      const stepDefinition = getStepDefinition();
+
+      await stepDefinition.handler(syncMockContext as never);
+
+      expect(mockResolveConnectorDetails).toHaveBeenCalledWith({
+        actionsClient: mockActionsClient,
+        connectorId: 'test-connector',
+        inference: undefined,
+        logger: mockLogger,
+        request: { headers: {} },
+      });
+    });
+  });
+
+  describe('sync mode', () => {
+    it('returns discoveries without replacements', async () => {
+      const stepDefinition = getStepDefinition();
+
+      const result = await stepDefinition.handler(syncMockContext as never);
+
+      expect(result.output).toEqual({
+        alerts_context_count: 5,
+        attack_discoveries: [
+          {
+            alert_ids: ['alert-1'],
+            details_markdown: 'Details about the attack',
+            entity_summary_markdown: 'Entity summary',
+            mitre_attack_tactics: ['Initial Access'],
+            summary_markdown: 'A summary',
+            title: 'Test Discovery',
+          },
+        ],
+        discovery_count: 1,
+        execution_uuid: 'test-execution-uuid',
+      });
+    });
+
+    it('returns execution_uuid from the generation result', async () => {
+      const stepDefinition = getStepDefinition();
+
+      const result = await stepDefinition.handler(syncMockContext as never);
+
+      expect(result.output?.execution_uuid).toBe('test-execution-uuid');
+    });
+
+    it('returns alerts_context_count from the retrieval result', async () => {
+      const stepDefinition = getStepDefinition();
+
+      const result = await stepDefinition.handler(syncMockContext as never);
+
+      expect(result.output?.alerts_context_count).toBe(5);
+    });
+
+    it('returns discovery_count from the validation result', async () => {
+      const stepDefinition = getStepDefinition();
+
+      const result = await stepDefinition.handler(syncMockContext as never);
+
+      expect(result.output?.discovery_count).toBe(1);
+    });
+
+    it('returns null attack_discoveries when validation fails', async () => {
+      mockExecuteGenerationWorkflow.mockResolvedValue({
+        outcome: 'validation_failed',
+      });
+
+      const stepDefinition = getStepDefinition();
+
+      const result = await stepDefinition.handler(syncMockContext as never);
+
+      expect(result.output).toEqual({
+        alerts_context_count: 0,
+        attack_discoveries: null,
+        discovery_count: 0,
+        execution_uuid: 'test-execution-uuid',
+      });
+    });
+  });
+
+  describe('async mode', () => {
+    it('returns execution_uuid only', async () => {
+      const stepDefinition = getStepDefinition();
+
+      const result = await stepDefinition.handler(asyncMockContext as never);
+
+      expect(result.output).toEqual({
+        execution_uuid: 'test-execution-uuid',
+      });
+    });
+
+    it('does not await executeGenerationWorkflow', async () => {
+      const stepDefinition = getStepDefinition();
+
+      await stepDefinition.handler(asyncMockContext as never);
+
+      expect(mockExecuteGenerationWorkflow).toHaveBeenCalled();
+    });
+  });
+
+  describe('replacements map NEVER appears in output', () => {
+    it('does not include replacements in sync mode output', async () => {
+      const stepDefinition = getStepDefinition();
+
+      const result = await stepDefinition.handler(syncMockContext as never);
+
+      const outputJson = JSON.stringify(result.output);
+      expect(outputJson).not.toContain('real-value-1');
+      expect(outputJson).not.toContain('real-value-2');
+      expect(outputJson).not.toContain('"replacements"');
+    });
+
+    it('does not include replacements in async mode output', async () => {
+      const stepDefinition = getStepDefinition();
+
+      const result = await stepDefinition.handler(asyncMockContext as never);
+
+      const outputJson = JSON.stringify(result.output);
+      expect(outputJson).not.toContain('real-value-1');
+      expect(outputJson).not.toContain('real-value-2');
+      expect(outputJson).not.toContain('"replacements"');
+    });
+
+    it('does not include replacements in validation-failed output', async () => {
+      mockExecuteGenerationWorkflow.mockResolvedValue({
+        outcome: 'validation_failed',
+      });
+
+      const stepDefinition = getStepDefinition();
+
+      const result = await stepDefinition.handler(syncMockContext as never);
+
+      const outputJson = JSON.stringify(result.output);
+      expect(outputJson).not.toContain('"replacements"');
+    });
+  });
+
+  describe('additional_context', () => {
+    it('passes additional_context to workflowConfig when provided', async () => {
+      const contextWithAdditionalContext = {
+        ...baseMockContext,
+        input: {
+          ...syncMockContext.input,
+          additional_context: 'Focus on lateral movement',
+        },
+      };
+
+      const stepDefinition = getStepDefinition();
+
+      await stepDefinition.handler(contextWithAdditionalContext as never);
+
+      expect(mockExecuteGenerationWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workflowConfig: expect.objectContaining({
+            additional_context: 'Focus on lateral movement',
+          }),
+        })
+      );
+    });
+
+    it('does NOT include additional_context in workflowConfig when not provided', async () => {
+      const stepDefinition = getStepDefinition();
+
+      await stepDefinition.handler(syncMockContext as never);
+
+      const callArgs = mockExecuteGenerationWorkflow.mock.calls[0][0];
+
+      expect(callArgs.workflowConfig).not.toHaveProperty('additional_context');
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns an error when executeGenerationWorkflow throws', async () => {
+      mockExecuteGenerationWorkflow.mockRejectedValue(new Error('Pipeline failed'));
+
+      const stepDefinition = getStepDefinition();
+
+      const result = await stepDefinition.handler(syncMockContext as never);
+
+      expect(result.error).toBeDefined();
+      expect(result.error?.message).toBe('Pipeline failed');
+    });
+
+    it('returns an error when connector resolution fails', async () => {
+      mockResolveConnectorDetails.mockRejectedValue(new Error('Connector not found'));
+
+      const stepDefinition = getStepDefinition();
+
+      const result = await stepDefinition.handler(syncMockContext as never);
+
+      expect(result.error).toBeDefined();
+      expect(result.error?.message).toBe('Connector not found');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/run_step/get_run_step_definition.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/run_step/get_run_step_definition.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AnalyticsServiceSetup, CoreStart, Logger } from '@kbn/core/server';
+import type { IEventLogger } from '@kbn/event-log-plugin/server';
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import { v4 as uuidv4 } from 'uuid';
+import { executeGenerationWorkflow } from '@kbn/discoveries/impl/attack_discovery/generation/execute_generation_workflow';
+import type { WorkflowConfig } from '@kbn/discoveries/impl/attack_discovery/generation/types';
+
+import { RunStepCommonDefinition } from '../../../../common/step_types/run_step';
+import type { DiscoveriesPluginStartDeps } from '../../../types';
+import { resolveConnectorDetails } from '../../helpers/resolve_connector_details';
+import type { WorkflowInitializationService } from '../../../lib/workflow_initialization';
+
+/**
+ * Server-side implementation of the Attack Discovery run step.
+ *
+ * Orchestrates the full pipeline (alert retrieval → generation → validation)
+ * in a single workflow step. Supports sync mode (returns discoveries inline)
+ * and async mode (fire-and-forget, returns execution_uuid only).
+ *
+ * The `replacements` map is explicitly excluded from the output for security.
+ */
+export const getRunStepDefinition = ({
+  analytics,
+  getEventLogIndex,
+  getEventLogger,
+  getStartServices,
+  logger,
+  workflowInitService,
+  workflowsManagementApi,
+}: {
+  analytics?: AnalyticsServiceSetup;
+  getEventLogIndex: () => Promise<string>;
+  getEventLogger: () => Promise<IEventLogger>;
+  getStartServices: () => Promise<{
+    coreStart: CoreStart;
+    pluginsStart: DiscoveriesPluginStartDeps;
+  }>;
+  logger: Logger;
+  workflowInitService: WorkflowInitializationService;
+  workflowsManagementApi?: WorkflowsServerPluginSetup['management'];
+}) =>
+  createServerStepDefinition({
+    ...RunStepCommonDefinition,
+    handler: async (context) => {
+      try {
+        const {
+          additional_context: additionalContext,
+          alert_retrieval_mode: alertRetrievalMode,
+          alert_retrieval_workflow_ids: alertRetrievalWorkflowIds,
+          alerts,
+          connector_id: connectorId,
+          end,
+          esql_query: esqlQuery,
+          filter,
+          mode,
+          size,
+          start,
+          validation_workflow_id: validationWorkflowId,
+        } = context.input;
+
+        const executionUuid = uuidv4();
+
+        context.logger.info(
+          `Starting Attack Discovery run step (mode=${mode}, connector=${connectorId})`
+        );
+
+        const { pluginsStart } = await getStartServices();
+        const request = context.contextManager.getFakeRequest();
+
+        const actionsClient = await pluginsStart.actions.getActionsClientWithRequest(request);
+
+        const { actionTypeId } = await resolveConnectorDetails({
+          actionsClient,
+          connectorId,
+          inference: pluginsStart.inference,
+          logger,
+          request,
+        });
+
+        const apiConfig = {
+          action_type_id: actionTypeId,
+          connector_id: connectorId,
+        };
+
+        const workflowConfig: WorkflowConfig = {
+          ...(additionalContext != null ? { additional_context: additionalContext } : {}),
+          alert_retrieval_workflow_ids: alertRetrievalWorkflowIds,
+          default_alert_retrieval_mode:
+            alerts != null && alerts.length > 0 ? 'provided' : alertRetrievalMode,
+          esql_query: esqlQuery,
+          provided_context: alerts,
+          validation_workflow_id: validationWorkflowId,
+        };
+
+        const executeParams = {
+          alertsIndexPattern: '.alerts-security.alerts-default',
+          analytics,
+          apiConfig,
+          end,
+          executionUuid,
+          filter,
+          getEventLogIndex,
+          getEventLogger,
+          getStartServices: async () => {
+            const services = await getStartServices();
+            return {
+              coreStart: services.coreStart,
+              pluginsStart: services.pluginsStart as unknown,
+            };
+          },
+          logger,
+          request,
+          size,
+          start,
+          trigger: 'workflow',
+          type: 'attack_discovery',
+          workflowConfig,
+          workflowInitService,
+          workflowsManagementApi,
+        };
+
+        if (mode === 'async') {
+          executeGenerationWorkflow(executeParams).catch((err) => {
+            logger.error(
+              `Async Attack Discovery run failed (execution=${executionUuid}): ${
+                err instanceof Error ? err.message : String(err)
+              }`
+            );
+          });
+
+          return {
+            output: {
+              execution_uuid: executionUuid,
+            },
+          };
+        }
+
+        const outcome = await executeGenerationWorkflow(executeParams);
+
+        if (outcome.outcome === 'validation_succeeded') {
+          const { alertRetrievalResult, generationResult, validationResult } = outcome;
+
+          return {
+            output: {
+              alerts_context_count: alertRetrievalResult.alertsContextCount,
+              attack_discoveries: generationResult.attackDiscoveries as Array<{
+                alert_ids: string[];
+                details_markdown: string;
+                entity_summary_markdown?: string;
+                id?: string;
+                mitre_attack_tactics?: string[];
+                summary_markdown: string;
+                timestamp?: string;
+                title: string;
+              }>,
+              discovery_count: validationResult.generatedCount,
+              execution_uuid: generationResult.executionUuid,
+            },
+          };
+        }
+
+        context.logger.warn(`Attack Discovery validation failed (execution=${executionUuid})`);
+
+        return {
+          output: {
+            alerts_context_count: 0,
+            attack_discoveries: null,
+            discovery_count: 0,
+            execution_uuid: executionUuid,
+          },
+        };
+      } catch (error) {
+        context.logger.error(
+          `Attack Discovery run step failed: ${
+            error instanceof Error ? error.message : 'Unknown error'
+          }`,
+          error instanceof Error ? error : undefined
+        );
+
+        return {
+          error: new Error(
+            error instanceof Error ? error.message : 'Attack Discovery run step failed'
+          ),
+        };
+      }
+    },
+  });

--- a/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/run_step/index.ts
+++ b/x-pack/solutions/security/plugins/discoveries/server/workflows/steps/run_step/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getRunStepDefinition } from './get_run_step_definition';

--- a/x-pack/solutions/security/plugins/discoveries/system_workflow_workarounds.md
+++ b/x-pack/solutions/security/plugins/discoveries/system_workflow_workarounds.md
@@ -1,0 +1,142 @@
+# System Workflow Workarounds
+
+## Background
+
+The Attack Discovery 2.0 Workflows Integration ships **6 bundled workflows** (3 required, 3 optional/example) and **6 custom step types** as part of the `discoveries` plugin. These workflows are essential for Attack Discovery to function correctly.
+
+The Kibana Workflows platform does not yet have a first-class concept of **managed** or **system** workflows — bundled workflows are stored identically to user-created ones and are fully mutable via the Workflows UI and API. This means users can edit, disable, or delete workflows that Attack Discovery depends on, silently breaking the feature.
+
+To ship Attack Discovery 2.0 without waiting for platform support, we implemented **plugin-side workarounds** that approximate managed workflow behavior. This document describes those workarounds and maps them to the platform requirements defined in the [managed workflows feature request](#feature-request-reference).
+
+---
+
+## Workaround Systems
+
+### 1. WorkflowInitializationService (Lazy Per-Space Provisioning)
+
+A singleton service that ensures bundled workflows exist in each Kibana space. It runs **lazily on the first request** to a space (not on space creation), and:
+
+- Calls `registerDefaultWorkflows()` to create all 6 bundled workflows from YAML definitions
+- Caches initialization results per space to avoid redundant provisioning
+- Implements **exponential backoff** on failure (30s → 2min → 4min → 8min, etc.)
+- Eagerly initializes the `default` space when any non-default space is first accessed
+
+**Limitation:** Provisioning is request-triggered, not event-driven. Workflows won't exist in a space until the first Attack Discovery request is made there.
+
+### 2. Self-Healing Gateway (Verify-and-Repair)
+
+Before **every generation request**, a self-healing gate runs between workflow ID resolution and pre-execution validation. It verifies that stored workflows match their bundled definitions and repairs any drift:
+
+| Scenario | Detection | Repair Action |
+|----------|-----------|---------------|
+| **Workflow modified** | SHA-256 hash of stored YAML ≠ bundled hash | Overwrite with bundled YAML |
+| **Workflow deleted** (soft-delete) | `getWorkflowsByIds()` returns empty array | Recreate from bundled YAML |
+| **Workflow disabled** | `enabled === false` | Re-enable via `updateWorkflow({ enabled: true })` |
+| **Workflow missing** | Not found in space | Create from bundled YAML |
+
+Required workflow repair failures **abort generation**. Optional workflow failures are logged as warnings and generation continues.
+
+### 3. Tag-Based Discovery
+
+Without deterministic IDs, the plugin discovers its bundled workflows by searching for unique tags (e.g., `discoveries:attackDiscovery:generation`). This adds query overhead compared to direct ID lookup but provides a reliable discovery mechanism.
+
+---
+
+## Self-Healing Flow
+
+```mermaid
+flowchart TD
+    A["POST /internal/attack_discovery/_generate"] --> B["resolveDefaultWorkflowIds()"]
+    B --> C["verifyAndRepairWorkflows()"]
+
+    C --> D{"For each workflow:<br/>Fetch by ID"}
+
+    D -->|Not found / soft-deleted| E["handleMissingWorkflow()<br/>Recreate from bundled YAML"]
+    D -->|Found| F{"enabled?"}
+
+    F -->|No| G["handleDisabledWorkflow()<br/>Re-enable"]
+    F -->|Yes| H{"SHA-256 hash<br/>matches bundled?"}
+
+    H -->|Yes| I["intact — no action"]
+    H -->|No| J["handleModifiedWorkflow()<br/>Overwrite with bundled YAML"]
+
+    E --> K{"Repair<br/>succeeded?"}
+    G --> K
+    J --> K
+
+    K -->|Yes| L["repaired"]
+    K -->|No, required| M["repair_failed → abort generation"]
+    K -->|No, optional| N["warning logged → generation continues"]
+
+    I --> O["All workflows checked"]
+    L --> O
+    N --> O
+
+    O --> P["validatePreExecution()"]
+    P --> Q["Execute orchestrated pipeline"]
+
+    style M fill:#f96,stroke:#333
+    style L fill:#9f9,stroke:#333
+    style I fill:#9f9,stroke:#333
+    style N fill:#ff9,stroke:#333
+```
+
+### Repair Outcomes
+
+| Status | Meaning | Pipeline Effect | Telemetry |
+|--------|---------|-----------------|-----------|
+| `all_intact` | All workflows match bundled definitions | Continues | None |
+| `repaired` | One or more workflows restored | Continues | `workflow_modified` event per workflow |
+| `repair_failed` | Required workflow(s) could not be restored | **Aborted** with `generation-failed` event | None (pipeline aborted) |
+
+---
+
+## Requirements Mapping
+
+The table below maps each requirement from the managed workflows feature request to the workaround implemented (if any) in the `discoveries` plugin.
+
+| # | Requirement | Priority | Workaround Status | Workaround Description |
+|---|-------------|----------|-------------------|------------------------|
+| **R1** | Managed/system workflow flag | P0 | **Partial** | No `managed` flag exists. Self-healing treats bundled workflows as immutable by reverting any user changes before each generation run. |
+| **R2** | Server-side enforcement of read-only | P0 | **Partial** | No API-level enforcement (users can still call `PUT`/`DELETE` on bundled workflows). Changes are reverted reactively by the self-healing gate on the next generation request, not proactively blocked. |
+| **R3** | UI enforcement + indication | P1 | **No workaround** — deferred to platform | Bundled workflows appear identical to user workflows in the Workflows UI. No visual distinction, and edit/delete actions are fully available. |
+| **R4** | Plugin-level bundled workflow registration API | P1 | **Yes** | `WorkflowInitializationService` + `registerDefaultWorkflows()` implements plugin-level provisioning from bundled YAML definitions, with per-space caching, retry/backoff, and cache invalidation on repair. |
+| **R5** | Automatic provisioning for new spaces | P1 | **Partial** | Provisioning is lazy (triggered on first request to a space), not event-driven on space creation. Also eagerly initializes the `default` space alongside non-default spaces. Workflows won't exist in a space until first use. |
+| **R6** | Deterministic IDs for bundled workflows | P2 | **No workaround** — deferred to platform | IDs are auto-generated. Plugin discovers workflows via tag-based search, adding query overhead and complexity. |
+| **R7** | Version/hash tracking for bundled workflows | P2 | **Yes** | SHA-256 hashes are computed from bundled YAML at first access and cached. Stored workflow YAML is hashed and compared against the bundled hash to detect drift without full string comparison. |
+| **R8** | Clone managed workflows into user-owned | P1 | **No workaround** — deferred to platform | The existing clone API works but has no `managed` concept to distinguish the clone from the original. |
+| **R9** | Privileged update path for managed workflows | P1 | **Yes** | Self-healing serves as the upgrade path: when a plugin ships updated bundled YAML, the hash mismatch triggers an overwrite on the next generation request, effectively applying the update. |
+| **R10** | Prevent disable of managed workflows | P2 | **Yes** | The G1 self-healing fix (commit `ccbc1888`) detects disabled workflows (`enabled === false`) and re-enables them before generation. Disabled state is reverted reactively, not prevented. |
+
+### Summary
+
+- **Fully addressed (4):** R4, R7, R9, R10
+- **Partially addressed (3):** R1, R2, R5
+- **Not addressed (3):** R3, R6, R8
+
+All workarounds are **reactive** (detect-and-repair) rather than **preventive** (block-and-reject). This means there is always a window between a user's mutation and the next generation request where the system is in a degraded state. A first-class managed workflow concept from the platform would eliminate this window and the plugin-side complexity entirely.
+
+---
+
+## References
+
+### READMEs
+
+- [Plugin README — Self-Healing section](./README.md) — Algorithm, outcomes table, error visibility matrix
+- [Workflow Definitions README](./server/workflows/definitions/readme.md) — Bundled workflow definitions and self-healing cross-reference
+- [Workflow Steps README](./server/workflows/steps/README.md) — All 6 step types with inputs/outputs
+
+### Key Implementation Files
+
+| File | Purpose |
+|------|---------|
+| `server/lib/workflow_initialization/index.ts` | `WorkflowInitializationService` — lazy per-space provisioning with retry/backoff |
+| `server/lib/workflow_initialization/verify_and_repair_workflows/index.ts` | Self-healing: detect drift, re-enable, recreate, overwrite |
+| `server/workflows/helpers/get_bundled_yaml_entries/index.ts` | Load bundled YAML files and compute SHA-256 hashes |
+| `@kbn/discoveries` `impl/attack_discovery/generation/verify_workflow_integrity/index.ts` | Integration point: calls verify-and-repair, handles telemetry |
+| `@kbn/discoveries` `impl/attack_discovery/generation/execute_generation_workflow.ts` | Execution flow: invokes self-healing gate before pipeline |
+
+### Commits
+
+- [`ccbc1888`](https://github.com/elastic/kibana/commit/ccbc1888fcf27a16d2a30abd029248c643e198eb) — Fix self-healing gaps G1 (disabled detection), G2 (soft-delete handling), G6 (optional workflow coverage)
+- [`fc37af65`](https://github.com/elastic/kibana/commit/fc37af65c3a5a609efa97bbb4bfe0709936fe0ff) — Document self-healing algorithm, run/notify steps, and execution flow in READMEs

--- a/x-pack/solutions/security/plugins/discoveries/test/scout/api/README.md
+++ b/x-pack/solutions/security/plugins/discoveries/test/scout/api/README.md
@@ -1,0 +1,68 @@
+# Discoveries - Scout API Tests
+
+Scout API integration tests for the `discoveries` plugin's internal routes.
+
+## Prerequisites
+
+Stop any locally running Elasticsearch and Kibana instances before starting the Scout server.
+
+## Running
+
+### Start the server (stateful)
+
+```sh
+node scripts/scout.js start-server --location local --arch stateful --domain classic
+```
+
+### Or serverless (security complete)
+
+```sh
+node scripts/scout.js start-server --location local --arch serverless --domain security_complete
+```
+
+### Run the tests
+
+```sh
+npx playwright test --config x-pack/solutions/security/plugins/discoveries/test/scout/api/playwright.config.ts --project=local
+```
+
+## Test Structure
+
+```
+test/scout/api/
+├── playwright.config.ts        # Scout Playwright configuration
+├── README.md                   # This file
+├── fixtures/
+│   ├── constants.ts            # Route paths, headers, tags
+│   └── helpers.ts              # API wrappers, mock data, cleanup utilities
+└── tests/
+    ├── scaffold_verification.spec.ts  # Scaffold smoke test (skipped)
+    ├── create.spec.ts                 # CRUD: create schedule
+    ├── get.spec.ts                    # CRUD: get schedule by id
+    ├── find.spec.ts                   # CRUD: find/list schedules
+    ├── update.spec.ts                 # CRUD: update schedule
+    ├── delete.spec.ts                 # CRUD: delete schedule
+    ├── enable.spec.ts                 # Lifecycle: enable schedule
+    ├── disable.spec.ts                # Lifecycle: disable schedule
+    ├── rbac.spec.ts                   # RBAC: 403 for unauthorized users
+    └── isolation.spec.ts              # Tag-based API isolation
+```
+
+## Test Utilities
+
+| Utility | Purpose |
+|---------|---------|
+| `getSimpleWorkflowSchedule()` | Returns a minimal valid internal schedule body |
+| `getSimplePublicSchedule()` | Returns a minimal valid public schedule body |
+| `getWorkflowSchedulesApis()` | Wraps all 7 internal schedule routes with auth headers |
+| `getPublicSchedulesApis()` | Wraps public schedule routes with auth and version headers |
+| `enableWorkflowSchedulesFeature()` | Enables the feature flag via UI settings |
+| `deleteAllWorkflowSchedules()` | Cleans up all internal schedules for test isolation |
+| `deleteAllPublicSchedules()` | Cleans up all public schedules for test isolation |
+
+## Test Categories
+
+- **CRUD** (`create`, `get`, `find`, `update`, `delete`): Full lifecycle with happy paths, defaults, validation errors, pagination, and sorting
+- **Lifecycle** (`enable`, `disable`): State transitions and 404 handling
+- **RBAC** (`rbac`): Verifies 403 responses for unauthorized (viewer) users across all write operations
+- **Isolation** (`isolation`): Tag-based isolation between internal and public schedule APIs

--- a/x-pack/solutions/security/plugins/discoveries/test/scout/api/fixtures/constants.ts
+++ b/x-pack/solutions/security/plugins/discoveries/test/scout/api/fixtures/constants.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-security';
+
+export const COMMON_HEADERS = {
+  'Content-Type': 'application/json;charset=UTF-8',
+  'kbn-xsrf': 'some-xsrf-token',
+  'x-elastic-internal-origin': 'kibana',
+} as const;
+
+/**
+ * Internal schedule API routes for discoveries.
+ *
+ * These mirror the 7 internal routes defined in the OpenAPI schemas
+ * (bead kibana-9p4.2) and implemented in bead kibana-9p4.6.
+ */
+export const SCHEDULE_ROUTES = {
+  CREATE: 'internal/attack_discovery/schedules',
+  DELETE: (id: string) => `internal/attack_discovery/schedules/${id}`,
+  DISABLE: (id: string) => `internal/attack_discovery/schedules/${id}/_disable`,
+  ENABLE: (id: string) => `internal/attack_discovery/schedules/${id}/_enable`,
+  FIND: 'internal/attack_discovery/schedules/_find',
+  GET: (id: string) => `internal/attack_discovery/schedules/${id}`,
+  UPDATE: (id: string) => `internal/attack_discovery/schedules/${id}`,
+} as const;
+
+/**
+ * Public attack discovery schedule API routes in elastic_assistant.
+ * Used by isolation tests to verify tag-based separation.
+ */
+export const PUBLIC_SCHEDULE_ROUTES = {
+  CREATE: 'api/attack_discovery/schedules',
+  DELETE: (id: string) => `api/attack_discovery/schedules/${id}`,
+  FIND: 'api/attack_discovery/schedules/_find',
+  GET: (id: string) => `api/attack_discovery/schedules/${id}`,
+} as const;
+
+export const SCHEDULE_TAGS = [...tags.stateful.classic, ...tags.serverless.security.complete];
+
+/**
+ * Tag used by the internal schedule API to isolate its alerting rules
+ * from the public schedule API in elastic_assistant.
+ */
+export const INTERNAL_SCHEDULE_TAG = 'attack-discovery-schedule';

--- a/x-pack/solutions/security/plugins/discoveries/test/scout/api/fixtures/helpers.ts
+++ b/x-pack/solutions/security/plugins/discoveries/test/scout/api/fixtures/helpers.ts
@@ -1,0 +1,254 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KbnClient } from '@kbn/scout-security';
+import { COMMON_HEADERS, PUBLIC_SCHEDULE_ROUTES, SCHEDULE_ROUTES } from './constants';
+
+/**
+ * API client shape required by schedule test helpers.
+ * Use this instead of importing Scout's ApiClient type directly.
+ */
+export interface ScheduleApiClient {
+  delete(
+    url: string,
+    options: {
+      headers: Record<string, string>;
+      responseType: 'json';
+    }
+  ): Promise<{ body: unknown; statusCode: number }>;
+  get(
+    url: string,
+    options: {
+      headers: Record<string, string>;
+      responseType: 'json';
+    }
+  ): Promise<{ body: unknown; statusCode: number }>;
+  post(
+    url: string,
+    options: {
+      body: unknown;
+      headers: Record<string, string>;
+      responseType: 'json';
+    }
+  ): Promise<{ body: unknown; statusCode: number }>;
+  put(
+    url: string,
+    options: {
+      body: unknown;
+      headers: Record<string, string>;
+      responseType: 'json';
+    }
+  ): Promise<{ body: unknown; statusCode: number }>;
+}
+
+/**
+ * Returns a minimal valid workflow schedule body for creating a schedule
+ * via the internal API. Matches the AttackDiscoveryScheduleCreateProps schema.
+ */
+export const getSimpleWorkflowSchedule = (
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> => ({
+  actions: [],
+  enabled: false,
+  name: 'Test workflow schedule',
+  params: {
+    alerts_index_pattern: '.alerts-security.alerts-default',
+    api_config: {
+      action_type_id: '.gen-ai',
+      connector_id: 'test-connector-id',
+    },
+    size: 20,
+    workflow_config: {
+      alert_retrieval_workflow_ids: [],
+      default_alert_retrieval_mode: 'custom_query',
+    },
+  },
+  schedule: {
+    interval: '24h',
+  },
+  ...overrides,
+});
+
+/**
+ * Returns a minimal valid schedule body for the public API.
+ * The public API uses camelCase inside api_config and has no workflow_config.
+ */
+export const getSimplePublicSchedule = (
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> => ({
+  actions: [],
+  enabled: false,
+  name: 'Test public schedule',
+  params: {
+    alerts_index_pattern: '.alerts-security.alerts-default',
+    api_config: {
+      actionTypeId: '.gen-ai',
+      connectorId: 'test-connector-id',
+    },
+    size: 20,
+  },
+  schedule: {
+    interval: '24h',
+  },
+  ...overrides,
+});
+
+/**
+ * Convenience wrapper around the internal schedule API routes.
+ * Encapsulates auth headers and route paths for cleaner test code.
+ */
+export const getWorkflowSchedulesApis = (
+  apiClient: ScheduleApiClient,
+  headers: Record<string, string>
+) => {
+  const defaultHeaders = { ...headers, ...COMMON_HEADERS };
+
+  return {
+    createSchedule: (body: Record<string, unknown>) =>
+      apiClient.post(SCHEDULE_ROUTES.CREATE, {
+        body,
+        headers: defaultHeaders,
+        responseType: 'json',
+      }),
+
+    deleteSchedule: (id: string) =>
+      apiClient.delete(SCHEDULE_ROUTES.DELETE(id), {
+        headers: defaultHeaders,
+        responseType: 'json',
+      }),
+
+    disableSchedule: (id: string) =>
+      apiClient.post(SCHEDULE_ROUTES.DISABLE(id), {
+        body: {},
+        headers: defaultHeaders,
+        responseType: 'json',
+      }),
+
+    enableSchedule: (id: string) =>
+      apiClient.post(SCHEDULE_ROUTES.ENABLE(id), {
+        body: {},
+        headers: defaultHeaders,
+        responseType: 'json',
+      }),
+
+    findSchedules: (query: Record<string, unknown> = {}) =>
+      apiClient.get(
+        `${SCHEDULE_ROUTES.FIND}?${new URLSearchParams(
+          query as Record<string, string>
+        ).toString()}`,
+        {
+          headers: defaultHeaders,
+          responseType: 'json',
+        }
+      ),
+
+    getSchedule: (id: string) =>
+      apiClient.get(SCHEDULE_ROUTES.GET(id), {
+        headers: defaultHeaders,
+        responseType: 'json',
+      }),
+
+    updateSchedule: (id: string, body: Record<string, unknown>) =>
+      apiClient.put(SCHEDULE_ROUTES.UPDATE(id), {
+        body,
+        headers: defaultHeaders,
+        responseType: 'json',
+      }),
+  };
+};
+
+/**
+ * Convenience wrapper around the public attack discovery schedule API routes.
+ * Used by isolation tests to create/find schedules via the public API.
+ */
+export const getPublicSchedulesApis = (
+  apiClient: ScheduleApiClient,
+  headers: Record<string, string>
+) => {
+  const defaultHeaders = {
+    ...headers,
+    ...COMMON_HEADERS,
+    'elastic-api-version': '2023-10-31',
+  };
+
+  return {
+    createSchedule: (body: Record<string, unknown>) =>
+      apiClient.post(PUBLIC_SCHEDULE_ROUTES.CREATE, {
+        body,
+        headers: defaultHeaders,
+        responseType: 'json',
+      }),
+
+    deleteSchedule: (id: string) =>
+      apiClient.delete(PUBLIC_SCHEDULE_ROUTES.DELETE(id), {
+        headers: defaultHeaders,
+        responseType: 'json',
+      }),
+
+    findSchedules: (query: Record<string, unknown> = {}) =>
+      apiClient.get(
+        `${PUBLIC_SCHEDULE_ROUTES.FIND}?${new URLSearchParams(
+          query as Record<string, string>
+        ).toString()}`,
+        {
+          headers: defaultHeaders,
+          responseType: 'json',
+        }
+      ),
+
+    getSchedule: (id: string) =>
+      apiClient.get(PUBLIC_SCHEDULE_ROUTES.GET(id), {
+        headers: defaultHeaders,
+        responseType: 'json',
+      }),
+  };
+};
+
+/**
+ * Enables the workflow schedules feature flag via kibana advanced settings.
+ * Call this in beforeAll to ensure the internal schedule API is available.
+ */
+export const enableWorkflowSchedulesFeature = async (kbnClient: KbnClient): Promise<void> => {
+  await kbnClient.uiSettings.update({
+    'securitySolution:securityAttackDiscoverySchedulesEnabled': true,
+  });
+};
+
+/**
+ * Deletes all workflow schedules created during test runs.
+ * Call this in afterAll/afterEach for test isolation.
+ */
+export const deleteAllWorkflowSchedules = async (
+  apiClient: ScheduleApiClient,
+  headers: Record<string, string>
+): Promise<void> => {
+  const apis = getWorkflowSchedulesApis(apiClient, headers);
+  const findResult = await apis.findSchedules({ per_page: '100' });
+  const body = findResult.body as { data?: Array<{ id: string }> };
+  const schedules = body.data ?? [];
+
+  for (const schedule of schedules) {
+    await apis.deleteSchedule(schedule.id);
+  }
+};
+
+/**
+ * Deletes all public attack discovery schedules created during test runs.
+ */
+export const deleteAllPublicSchedules = async (
+  apiClient: ScheduleApiClient,
+  headers: Record<string, string>
+): Promise<void> => {
+  const apis = getPublicSchedulesApis(apiClient, headers);
+  const findResult = await apis.findSchedules({ per_page: '100' });
+  const body = findResult.body as { data?: Array<{ id: string }> };
+  const schedules = body.data ?? [];
+
+  for (const schedule of schedules) {
+    await apis.deleteSchedule(schedule.id);
+  }
+};

--- a/x-pack/solutions/security/plugins/discoveries/test/scout/api/playwright.config.ts
+++ b/x-pack/solutions/security/plugins/discoveries/test/scout/api/playwright.config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout-security';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+});

--- a/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/create.spec.ts
+++ b/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/create.spec.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import { SCHEDULE_TAGS } from '../fixtures/constants';
+import {
+  deleteAllWorkflowSchedules,
+  getSimpleWorkflowSchedule,
+  getWorkflowSchedulesApis,
+} from '../fixtures/helpers';
+
+apiTest.describe('Workflow schedule API - create', { tag: SCHEDULE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = { ...credentials.cookieHeader };
+  });
+
+  apiTest.afterEach(async ({ apiClient }) => {
+    await deleteAllWorkflowSchedules(apiClient, defaultHeaders);
+  });
+
+  apiTest('should create a schedule with all fields', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+    const scheduleBody = getSimpleWorkflowSchedule();
+
+    const { body, statusCode } = await apis.createSchedule(scheduleBody);
+
+    expect(statusCode).toBe(200);
+
+    const schedule = body as Record<string, unknown>;
+    expect(schedule.id).toBeDefined();
+    expect(schedule.name).toBe('Test workflow schedule');
+    expect(schedule.enabled).toBe(false);
+    expect(schedule.created_by).toBeDefined();
+    expect(schedule.updated_by).toBeDefined();
+    expect(schedule.created_at).toBeDefined();
+    expect(schedule.updated_at).toBeDefined();
+    expect(schedule.actions).toStrictEqual([]);
+    expect(schedule.schedule).toStrictEqual({ interval: '24h' });
+
+    const params = schedule.params as Record<string, unknown>;
+    expect(params.alerts_index_pattern).toBe('.alerts-security.alerts-default');
+    expect(params.size).toBe(20);
+
+    const apiConfig = params.api_config as Record<string, unknown>;
+    expect(apiConfig.action_type_id).toBe('.gen-ai');
+    expect(apiConfig.connector_id).toBe('test-connector-id');
+  });
+
+  apiTest('should default enabled to false when omitted', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+    const { enabled: _, ...scheduleWithoutEnabled } = getSimpleWorkflowSchedule();
+
+    const { body, statusCode } = await apis.createSchedule(scheduleWithoutEnabled);
+
+    expect(statusCode).toBe(200);
+    expect((body as Record<string, unknown>).enabled).toBe(false);
+  });
+
+  apiTest('should default actions to empty array when omitted', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+    const { actions: _, ...scheduleWithoutActions } = getSimpleWorkflowSchedule();
+
+    const { body, statusCode } = await apis.createSchedule(scheduleWithoutActions);
+
+    expect(statusCode).toBe(200);
+    expect((body as Record<string, unknown>).actions).toStrictEqual([]);
+  });
+
+  apiTest('should return 400 when name is missing', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+    const { name: _, ...scheduleWithoutName } = getSimpleWorkflowSchedule();
+
+    const { statusCode } = await apis.createSchedule(scheduleWithoutName);
+
+    expect(statusCode).toBe(400);
+  });
+
+  apiTest('should return 400 when params is missing', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+    const { params: _, ...scheduleWithoutParams } = getSimpleWorkflowSchedule();
+
+    const { statusCode } = await apis.createSchedule(scheduleWithoutParams);
+
+    expect(statusCode).toBe(400);
+  });
+
+  apiTest('should return 400 when schedule is missing', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+    const { schedule: _, ...scheduleWithoutSchedule } = getSimpleWorkflowSchedule();
+
+    const { statusCode } = await apis.createSchedule(scheduleWithoutSchedule);
+
+    expect(statusCode).toBe(400);
+  });
+
+  apiTest('should persist workflow_config params', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+    const scheduleBody = getSimpleWorkflowSchedule({
+      params: {
+        alerts_index_pattern: '.alerts-security.alerts-default',
+        api_config: {
+          action_type_id: '.gen-ai',
+          connector_id: 'test-connector-id',
+        },
+        size: 50,
+        workflow_config: {
+          alert_retrieval_workflow_ids: ['workflow-1', 'workflow-2'],
+          default_alert_retrieval_mode: 'disabled',
+          validation_workflow_id: 'custom-validation',
+        },
+      },
+    });
+
+    const { body, statusCode } = await apis.createSchedule(scheduleBody);
+
+    expect(statusCode).toBe(200);
+
+    const params = (body as Record<string, unknown>).params as Record<string, unknown>;
+    expect(params.size).toBe(50);
+  });
+
+  apiTest('should persist snake_case api_config fields', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+    const scheduleBody = getSimpleWorkflowSchedule({
+      params: {
+        alerts_index_pattern: '.alerts-security.alerts-default',
+        api_config: {
+          action_type_id: '.bedrock',
+          connector_id: 'bedrock-connector-123',
+          default_system_prompt_id: 'prompt-abc',
+          model: 'claude-3-sonnet',
+          name: 'My Bedrock Connector',
+        },
+        size: 100,
+      },
+    });
+
+    const { body, statusCode } = await apis.createSchedule(scheduleBody);
+
+    expect(statusCode).toBe(200);
+
+    const params = (body as Record<string, unknown>).params as Record<string, unknown>;
+    const apiConfig = params.api_config as Record<string, unknown>;
+    expect(apiConfig.action_type_id).toBe('.bedrock');
+    expect(apiConfig.connector_id).toBe('bedrock-connector-123');
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/delete.spec.ts
+++ b/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/delete.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import { SCHEDULE_TAGS } from '../fixtures/constants';
+import {
+  deleteAllWorkflowSchedules,
+  getSimpleWorkflowSchedule,
+  getWorkflowSchedulesApis,
+} from '../fixtures/helpers';
+
+apiTest.describe('Workflow schedule API - delete', { tag: SCHEDULE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = { ...credentials.cookieHeader };
+  });
+
+  apiTest.afterEach(async ({ apiClient }) => {
+    await deleteAllWorkflowSchedules(apiClient, defaultHeaders);
+  });
+
+  apiTest('should delete a schedule', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    const createResult = await apis.createSchedule(getSimpleWorkflowSchedule());
+    expect(createResult.statusCode).toBe(200);
+    const createdId = (createResult.body as Record<string, unknown>).id as string;
+
+    const { body, statusCode } = await apis.deleteSchedule(createdId);
+
+    expect(statusCode).toBe(200);
+    expect((body as Record<string, unknown>).id).toBe(createdId);
+
+    const getResult = await apis.getSchedule(createdId);
+    expect(getResult.statusCode).toBe(404);
+  });
+
+  apiTest('should return 404 when deleting non-existent schedule', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    const { statusCode } = await apis.deleteSchedule('non-existent-id-12345');
+
+    expect(statusCode).toBe(404);
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/disable.spec.ts
+++ b/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/disable.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import { SCHEDULE_TAGS } from '../fixtures/constants';
+import {
+  deleteAllWorkflowSchedules,
+  getSimpleWorkflowSchedule,
+  getWorkflowSchedulesApis,
+} from '../fixtures/helpers';
+
+apiTest.describe('Workflow schedule API - disable', { tag: SCHEDULE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = { ...credentials.cookieHeader };
+  });
+
+  apiTest.afterEach(async ({ apiClient }) => {
+    await deleteAllWorkflowSchedules(apiClient, defaultHeaders);
+  });
+
+  apiTest('should disable an enabled schedule', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    const createResult = await apis.createSchedule(getSimpleWorkflowSchedule({ enabled: true }));
+    expect(createResult.statusCode).toBe(200);
+    const createdId = (createResult.body as Record<string, unknown>).id as string;
+
+    const { body, statusCode } = await apis.disableSchedule(createdId);
+
+    expect(statusCode).toBe(200);
+    expect((body as Record<string, unknown>).id).toBe(createdId);
+
+    const getResult = await apis.getSchedule(createdId);
+    expect(getResult.statusCode).toBe(200);
+    expect((getResult.body as Record<string, unknown>).enabled).toBe(false);
+  });
+
+  apiTest('should return 404 for non-existent schedule', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    const { statusCode } = await apis.disableSchedule('non-existent-id-12345');
+
+    expect(statusCode).toBe(404);
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/enable.spec.ts
+++ b/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/enable.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import { SCHEDULE_TAGS } from '../fixtures/constants';
+import {
+  deleteAllWorkflowSchedules,
+  getSimpleWorkflowSchedule,
+  getWorkflowSchedulesApis,
+} from '../fixtures/helpers';
+
+apiTest.describe('Workflow schedule API - enable', { tag: SCHEDULE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = { ...credentials.cookieHeader };
+  });
+
+  apiTest.afterEach(async ({ apiClient }) => {
+    await deleteAllWorkflowSchedules(apiClient, defaultHeaders);
+  });
+
+  apiTest('should enable a disabled schedule', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    const createResult = await apis.createSchedule(getSimpleWorkflowSchedule({ enabled: false }));
+    expect(createResult.statusCode).toBe(200);
+    const createdId = (createResult.body as Record<string, unknown>).id as string;
+    expect((createResult.body as Record<string, unknown>).enabled).toBe(false);
+
+    const { body, statusCode } = await apis.enableSchedule(createdId);
+
+    expect(statusCode).toBe(200);
+    expect((body as Record<string, unknown>).id).toBe(createdId);
+
+    const getResult = await apis.getSchedule(createdId);
+    expect(getResult.statusCode).toBe(200);
+    expect((getResult.body as Record<string, unknown>).enabled).toBe(true);
+  });
+
+  apiTest('should return 404 for non-existent schedule', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    const { statusCode } = await apis.enableSchedule('non-existent-id-12345');
+
+    expect(statusCode).toBe(404);
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/find.spec.ts
+++ b/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/find.spec.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import { SCHEDULE_TAGS } from '../fixtures/constants';
+import {
+  deleteAllWorkflowSchedules,
+  getSimpleWorkflowSchedule,
+  getWorkflowSchedulesApis,
+} from '../fixtures/helpers';
+
+apiTest.describe('Workflow schedule API - find', { tag: SCHEDULE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = { ...credentials.cookieHeader };
+  });
+
+  apiTest.afterEach(async ({ apiClient }) => {
+    await deleteAllWorkflowSchedules(apiClient, defaultHeaders);
+  });
+
+  apiTest('should return empty result when no schedules exist', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    const { body, statusCode } = await apis.findSchedules();
+
+    expect(statusCode).toBe(200);
+
+    const result = body as { data: unknown[]; page: number; per_page: number; total: number };
+    expect(result.data).toStrictEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  apiTest('should return all created schedules', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    await apis.createSchedule(getSimpleWorkflowSchedule({ name: 'Schedule A' }));
+    await apis.createSchedule(getSimpleWorkflowSchedule({ name: 'Schedule B' }));
+    await apis.createSchedule(getSimpleWorkflowSchedule({ name: 'Schedule C' }));
+
+    const { body, statusCode } = await apis.findSchedules();
+
+    expect(statusCode).toBe(200);
+
+    const result = body as { data: Array<{ name: string }>; total: number };
+    expect(result.total).toBe(3);
+    expect(result.data).toHaveLength(3);
+
+    const names = result.data.map((s) => s.name).sort();
+    expect(names).toStrictEqual(['Schedule A', 'Schedule B', 'Schedule C']);
+  });
+
+  apiTest('should sort by name ascending', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    await apis.createSchedule(getSimpleWorkflowSchedule({ name: 'Charlie' }));
+    await apis.createSchedule(getSimpleWorkflowSchedule({ name: 'Alpha' }));
+    await apis.createSchedule(getSimpleWorkflowSchedule({ name: 'Bravo' }));
+
+    const { body, statusCode } = await apis.findSchedules({
+      sort_field: 'name',
+      sort_direction: 'asc',
+    });
+
+    expect(statusCode).toBe(200);
+
+    const result = body as { data: Array<{ name: string }> };
+    const names = result.data.map((s) => s.name);
+    expect(names).toStrictEqual(['Alpha', 'Bravo', 'Charlie']);
+  });
+
+  apiTest('should sort by name descending', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    await apis.createSchedule(getSimpleWorkflowSchedule({ name: 'Charlie' }));
+    await apis.createSchedule(getSimpleWorkflowSchedule({ name: 'Alpha' }));
+    await apis.createSchedule(getSimpleWorkflowSchedule({ name: 'Bravo' }));
+
+    const { body, statusCode } = await apis.findSchedules({
+      sort_field: 'name',
+      sort_direction: 'desc',
+    });
+
+    expect(statusCode).toBe(200);
+
+    const result = body as { data: Array<{ name: string }> };
+    const names = result.data.map((s) => s.name);
+    expect(names).toStrictEqual(['Charlie', 'Bravo', 'Alpha']);
+  });
+
+  apiTest('should support pagination', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    for (let i = 1; i <= 5; i++) {
+      await apis.createSchedule(getSimpleWorkflowSchedule({ name: `Schedule ${i}` }));
+    }
+
+    const page1 = await apis.findSchedules({ page: '1', per_page: '2' });
+    expect(page1.statusCode).toBe(200);
+
+    const page1Body = page1.body as {
+      data: unknown[];
+      page: number;
+      per_page: number;
+      total: number;
+    };
+    expect(page1Body.data).toHaveLength(2);
+    expect(page1Body.total).toBe(5);
+    expect(page1Body.page).toBe(1);
+    expect(page1Body.per_page).toBe(2);
+
+    const page2 = await apis.findSchedules({ page: '2', per_page: '2' });
+    expect(page2.statusCode).toBe(200);
+
+    const page2Body = page2.body as { data: unknown[]; page: number };
+    expect(page2Body.data).toHaveLength(2);
+    expect(page2Body.page).toBe(2);
+
+    const page3 = await apis.findSchedules({ page: '3', per_page: '2' });
+    expect(page3.statusCode).toBe(200);
+
+    const page3Body = page3.body as { data: unknown[] };
+    expect(page3Body.data).toHaveLength(1);
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/get.spec.ts
+++ b/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/get.spec.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import { SCHEDULE_TAGS } from '../fixtures/constants';
+import {
+  deleteAllWorkflowSchedules,
+  getSimpleWorkflowSchedule,
+  getWorkflowSchedulesApis,
+} from '../fixtures/helpers';
+
+apiTest.describe('Workflow schedule API - get', { tag: SCHEDULE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = { ...credentials.cookieHeader };
+  });
+
+  apiTest.afterEach(async ({ apiClient }) => {
+    await deleteAllWorkflowSchedules(apiClient, defaultHeaders);
+  });
+
+  apiTest('should get a schedule by id', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+    const scheduleBody = getSimpleWorkflowSchedule();
+
+    const createResult = await apis.createSchedule(scheduleBody);
+    expect(createResult.statusCode).toBe(200);
+    const createdId = (createResult.body as Record<string, unknown>).id as string;
+
+    const { body, statusCode } = await apis.getSchedule(createdId);
+
+    expect(statusCode).toBe(200);
+
+    const schedule = body as Record<string, unknown>;
+    expect(schedule.id).toBe(createdId);
+    expect(schedule.name).toBe('Test workflow schedule');
+    expect(schedule.enabled).toBe(false);
+    expect(schedule.schedule).toStrictEqual({ interval: '24h' });
+  });
+
+  apiTest('should return 404 for non-existent schedule', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    const { statusCode } = await apis.getSchedule('non-existent-id-12345');
+
+    expect(statusCode).toBe(404);
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/isolation.spec.ts
+++ b/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/isolation.spec.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import { SCHEDULE_TAGS } from '../fixtures/constants';
+import {
+  deleteAllPublicSchedules,
+  deleteAllWorkflowSchedules,
+  getPublicSchedulesApis,
+  getSimplePublicSchedule,
+  getSimpleWorkflowSchedule,
+  getWorkflowSchedulesApis,
+} from '../fixtures/helpers';
+
+apiTest.describe('Workflow schedule API - isolation', { tag: SCHEDULE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = { ...credentials.cookieHeader };
+  });
+
+  apiTest.afterEach(async ({ apiClient }) => {
+    await deleteAllWorkflowSchedules(apiClient, defaultHeaders);
+    await deleteAllPublicSchedules(apiClient, defaultHeaders);
+  });
+
+  apiTest('internal API should not see schedules created by public API', async ({ apiClient }) => {
+    const publicApis = getPublicSchedulesApis(apiClient, defaultHeaders);
+    const internalApis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    const publicCreate = await publicApis.createSchedule(
+      getSimplePublicSchedule({ name: 'Public schedule' })
+    );
+    expect(publicCreate.statusCode).toBe(200);
+
+    const internalFind = await internalApis.findSchedules({ per_page: '100' });
+    expect(internalFind.statusCode).toBe(200);
+
+    const internalSchedules = (internalFind.body as { data: Array<{ name: string }> }).data;
+    const publicNames = internalSchedules.filter((s) => s.name === 'Public schedule');
+    expect(publicNames).toHaveLength(0);
+  });
+
+  apiTest(
+    'internal API can get a public schedule by id (by-ID operations are not tag-filtered)',
+    async ({ apiClient }) => {
+      const publicApis = getPublicSchedulesApis(apiClient, defaultHeaders);
+      const internalApis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+      const publicCreate = await publicApis.createSchedule(
+        getSimplePublicSchedule({ name: 'Public schedule for get' })
+      );
+      expect(publicCreate.statusCode).toBe(200);
+      const publicId = (publicCreate.body as Record<string, unknown>).id as string;
+
+      // By-ID operations (getSchedule) use rulesClient.get() which fetches by ID without
+      // tag filtering. Isolation is enforced at the find level (filterTags), not by-ID level.
+      const internalGet = await internalApis.getSchedule(publicId);
+      expect(internalGet.statusCode).toBe(200);
+    }
+  );
+
+  apiTest(
+    'internal API can delete a public schedule by id (by-ID operations are not tag-filtered)',
+    async ({ apiClient }) => {
+      const publicApis = getPublicSchedulesApis(apiClient, defaultHeaders);
+      const internalApis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+      const publicCreate = await publicApis.createSchedule(
+        getSimplePublicSchedule({ name: 'Public schedule for delete' })
+      );
+      expect(publicCreate.statusCode).toBe(200);
+      const publicId = (publicCreate.body as Record<string, unknown>).id as string;
+
+      // By-ID operations (deleteSchedule) use rulesClient.delete() which deletes by ID without
+      // tag filtering. Isolation is enforced at the find level (filterTags), not by-ID level.
+      const internalDelete = await internalApis.deleteSchedule(publicId);
+      expect(internalDelete.statusCode).toBe(200);
+
+      const publicGet = await publicApis.getSchedule(publicId);
+      expect(publicGet.statusCode).toBe(404);
+    }
+  );
+
+  apiTest(
+    'internal API find should only return its own schedules when both exist',
+    async ({ apiClient }) => {
+      const publicApis = getPublicSchedulesApis(apiClient, defaultHeaders);
+      const internalApis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+      await publicApis.createSchedule(getSimplePublicSchedule({ name: 'Public only' }));
+      await internalApis.createSchedule(getSimpleWorkflowSchedule({ name: 'Internal only' }));
+
+      const internalFind = await internalApis.findSchedules({ per_page: '100' });
+      expect(internalFind.statusCode).toBe(200);
+
+      const internalSchedules = (internalFind.body as { data: Array<{ name: string }> }).data;
+      expect(internalSchedules).toHaveLength(1);
+      expect(internalSchedules[0].name).toBe('Internal only');
+    }
+  );
+});

--- a/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/rbac.spec.ts
+++ b/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/rbac.spec.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import { SCHEDULE_TAGS } from '../fixtures/constants';
+import {
+  deleteAllWorkflowSchedules,
+  getSimpleWorkflowSchedule,
+  getWorkflowSchedulesApis,
+} from '../fixtures/helpers';
+
+apiTest.describe('Workflow schedule API - RBAC', { tag: SCHEDULE_TAGS }, () => {
+  let adminHeaders: Record<string, string>;
+  let viewerHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth }) => {
+    const adminCredentials = await samlAuth.asInteractiveUser('admin');
+    adminHeaders = { ...adminCredentials.cookieHeader };
+
+    const viewerCredentials = await samlAuth.asInteractiveUser('viewer');
+    viewerHeaders = { ...viewerCredentials.cookieHeader };
+  });
+
+  apiTest.afterEach(async ({ apiClient }) => {
+    await deleteAllWorkflowSchedules(apiClient, adminHeaders);
+  });
+
+  apiTest('should return 403 when unauthorized user creates a schedule', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, viewerHeaders);
+
+    const { statusCode } = await apis.createSchedule(getSimpleWorkflowSchedule());
+
+    expect(statusCode).toBe(403);
+  });
+
+  apiTest('should return 403 when unauthorized user updates a schedule', async ({ apiClient }) => {
+    const adminApis = getWorkflowSchedulesApis(apiClient, adminHeaders);
+    const viewerApis = getWorkflowSchedulesApis(apiClient, viewerHeaders);
+
+    const createResult = await adminApis.createSchedule(getSimpleWorkflowSchedule());
+    expect(createResult.statusCode).toBe(200);
+    const createdId = (createResult.body as Record<string, unknown>).id as string;
+
+    const { statusCode } = await viewerApis.updateSchedule(createdId, {
+      actions: [],
+      name: 'Hacked name',
+      params: {
+        alerts_index_pattern: '.alerts-security.alerts-default',
+        api_config: {
+          action_type_id: '.gen-ai',
+          connector_id: 'test-connector-id',
+        },
+        size: 20,
+      },
+      schedule: { interval: '24h' },
+    });
+
+    expect(statusCode).toBe(403);
+  });
+
+  apiTest('should return 403 when unauthorized user deletes a schedule', async ({ apiClient }) => {
+    const adminApis = getWorkflowSchedulesApis(apiClient, adminHeaders);
+    const viewerApis = getWorkflowSchedulesApis(apiClient, viewerHeaders);
+
+    const createResult = await adminApis.createSchedule(getSimpleWorkflowSchedule());
+    expect(createResult.statusCode).toBe(200);
+    const createdId = (createResult.body as Record<string, unknown>).id as string;
+
+    const { statusCode } = await viewerApis.deleteSchedule(createdId);
+
+    expect(statusCode).toBe(403);
+  });
+
+  apiTest('should return 403 when unauthorized user enables a schedule', async ({ apiClient }) => {
+    const adminApis = getWorkflowSchedulesApis(apiClient, adminHeaders);
+    const viewerApis = getWorkflowSchedulesApis(apiClient, viewerHeaders);
+
+    const createResult = await adminApis.createSchedule(
+      getSimpleWorkflowSchedule({ enabled: false })
+    );
+    expect(createResult.statusCode).toBe(200);
+    const createdId = (createResult.body as Record<string, unknown>).id as string;
+
+    const { statusCode } = await viewerApis.enableSchedule(createdId);
+
+    expect(statusCode).toBe(403);
+  });
+
+  apiTest('should return 403 when unauthorized user disables a schedule', async ({ apiClient }) => {
+    const adminApis = getWorkflowSchedulesApis(apiClient, adminHeaders);
+    const viewerApis = getWorkflowSchedulesApis(apiClient, viewerHeaders);
+
+    const createResult = await adminApis.createSchedule(
+      getSimpleWorkflowSchedule({ enabled: true })
+    );
+    expect(createResult.statusCode).toBe(200);
+    const createdId = (createResult.body as Record<string, unknown>).id as string;
+
+    const { statusCode } = await viewerApis.disableSchedule(createdId);
+
+    expect(statusCode).toBe(403);
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/scaffold_verification.spec.ts
+++ b/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/scaffold_verification.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import { SCHEDULE_TAGS } from '../fixtures/constants';
+import {
+  deleteAllWorkflowSchedules,
+  getSimpleWorkflowSchedule,
+  getWorkflowSchedulesApis,
+} from '../fixtures/helpers';
+
+/**
+ * Placeholder tests that verify the Scout test scaffold is wired up correctly.
+ * These will be replaced by full CRUD, lifecycle, RBAC, and isolation tests
+ * in bead kibana-9p4.11.
+ */
+apiTest.describe('Workflow schedule API - scaffold verification', { tag: SCHEDULE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = { ...credentials.cookieHeader };
+  });
+
+  apiTest.afterAll(async ({ apiClient }) => {
+    await deleteAllWorkflowSchedules(apiClient, defaultHeaders);
+  });
+
+  apiTest.skip(
+    'scaffold: can import test utilities without errors',
+
+    async ({ apiClient }) => {
+      const schedule = getSimpleWorkflowSchedule();
+      expect(schedule).toBeDefined();
+      expect(schedule.name).toBe('Test workflow schedule');
+
+      const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+      expect(apis.createSchedule).toBeDefined();
+      expect(apis.deleteSchedule).toBeDefined();
+      expect(apis.disableSchedule).toBeDefined();
+      expect(apis.enableSchedule).toBeDefined();
+      expect(apis.findSchedules).toBeDefined();
+      expect(apis.getSchedule).toBeDefined();
+      expect(apis.updateSchedule).toBeDefined();
+    }
+  );
+});

--- a/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/update.spec.ts
+++ b/x-pack/solutions/security/plugins/discoveries/test/scout/api/tests/update.spec.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import { SCHEDULE_TAGS } from '../fixtures/constants';
+import {
+  deleteAllWorkflowSchedules,
+  getSimpleWorkflowSchedule,
+  getWorkflowSchedulesApis,
+} from '../fixtures/helpers';
+
+apiTest.describe('Workflow schedule API - update', { tag: SCHEDULE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = { ...credentials.cookieHeader };
+  });
+
+  apiTest.afterEach(async ({ apiClient }) => {
+    await deleteAllWorkflowSchedules(apiClient, defaultHeaders);
+  });
+
+  apiTest('should update a schedule', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    const createResult = await apis.createSchedule(getSimpleWorkflowSchedule());
+    expect(createResult.statusCode).toBe(200);
+    const createdId = (createResult.body as Record<string, unknown>).id as string;
+
+    const updateBody = {
+      actions: [],
+      name: 'Updated schedule name',
+      params: {
+        alerts_index_pattern: '.alerts-security.alerts-default',
+        api_config: {
+          action_type_id: '.gen-ai',
+          connector_id: 'updated-connector-id',
+        },
+        size: 50,
+      },
+      schedule: {
+        interval: '12h',
+      },
+    };
+
+    const { body, statusCode } = await apis.updateSchedule(createdId, updateBody);
+
+    expect(statusCode).toBe(200);
+
+    const schedule = body as Record<string, unknown>;
+    expect(schedule.id).toBe(createdId);
+    expect(schedule.name).toBe('Updated schedule name');
+    expect(schedule.schedule).toStrictEqual({ interval: '12h' });
+
+    const params = schedule.params as Record<string, unknown>;
+    const apiConfig = params.api_config as Record<string, unknown>;
+    expect(apiConfig.connector_id).toBe('updated-connector-id');
+    expect(params.size).toBe(50);
+  });
+
+  apiTest('should return 400 when name is missing from update', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    const createResult = await apis.createSchedule(getSimpleWorkflowSchedule());
+    expect(createResult.statusCode).toBe(200);
+    const createdId = (createResult.body as Record<string, unknown>).id as string;
+
+    const { statusCode } = await apis.updateSchedule(createdId, {
+      actions: [],
+      params: {
+        alerts_index_pattern: '.alerts-security.alerts-default',
+        api_config: {
+          action_type_id: '.gen-ai',
+          connector_id: 'test-connector-id',
+        },
+        size: 20,
+      },
+      schedule: { interval: '24h' },
+    });
+
+    expect(statusCode).toBe(400);
+  });
+
+  apiTest('should return 404 when updating non-existent schedule', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    const { statusCode } = await apis.updateSchedule('non-existent-id-12345', {
+      actions: [],
+      name: 'Does not exist',
+      params: {
+        alerts_index_pattern: '.alerts-security.alerts-default',
+        api_config: {
+          action_type_id: '.gen-ai',
+          connector_id: 'test-connector-id',
+        },
+        size: 20,
+      },
+      schedule: { interval: '24h' },
+    });
+
+    expect(statusCode).toBe(404);
+  });
+
+  apiTest('should update workflow_config fields', async ({ apiClient }) => {
+    const apis = getWorkflowSchedulesApis(apiClient, defaultHeaders);
+
+    const createResult = await apis.createSchedule(getSimpleWorkflowSchedule());
+    expect(createResult.statusCode).toBe(200);
+    const createdId = (createResult.body as Record<string, unknown>).id as string;
+
+    const updateBody = {
+      actions: [],
+      name: 'Updated with workflow config',
+      params: {
+        alerts_index_pattern: '.alerts-security.alerts-default',
+        api_config: {
+          action_type_id: '.gen-ai',
+          connector_id: 'test-connector-id',
+        },
+        size: 20,
+        workflow_config: {
+          alert_retrieval_workflow_ids: ['workflow-abc'],
+          default_alert_retrieval_mode: 'disabled',
+          validation_workflow_id: 'custom-validation',
+        },
+      },
+      schedule: { interval: '24h' },
+    };
+
+    const { body, statusCode } = await apis.updateSchedule(createdId, updateBody);
+
+    expect(statusCode).toBe(200);
+
+    const schedule = body as Record<string, unknown>;
+    expect(schedule.name).toBe('Updated with workflow config');
+  });
+});

--- a/x-pack/solutions/security/plugins/discoveries/tsconfig.json
+++ b/x-pack/solutions/security/plugins/discoveries/tsconfig.json
@@ -1,0 +1,46 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "target/types"
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.d.ts"
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": [
+    "@kbn/agent-builder-common",
+    "@kbn/agent-builder-plugin",
+    "@kbn/agent-builder-server",
+    "@kbn/alerting-plugin",
+    "@kbn/attack-discovery-schedules-common",
+    "@kbn/config-schema",
+    "@kbn/core",
+    "@kbn/core-elasticsearch-server",
+    "@kbn/core-http-server",
+    "@kbn/core-http-server-utils",
+    "@kbn/core-saved-objects-server",
+    "@kbn/i18n",
+    "@kbn/kibana-react-plugin",
+    "@kbn/logging",
+    "@kbn/react-query",
+    "@kbn/rule-registry-plugin",
+    "@kbn/security-ai-prompts",
+    "@kbn/discoveries",
+    "@kbn/discoveries-schemas",
+    "@kbn/security-plugin",
+    "@kbn/scout-security",
+    "@kbn/security-solution-features",
+    "@kbn/securitysolution-es-utils",
+    "@kbn/spaces-plugin",
+    "@kbn/task-manager-plugin",
+    "@kbn/triggers-actions-ui-plugin",
+    "@kbn/workflows",
+    "@kbn/workflows-extensions",
+    "@kbn/workflows-management-plugin",
+    "@kbn/zod"
+  ]
+}


### PR DESCRIPTION
## [Attack Discovery] Attack Discovery 2.0: Workflows Integration 2 - Add discoveries plugin with workflow step registration
| | |
|---|---|
| **Stack** | PR 2 of 10 — base: `attack-discovery-workflows-integration/01-shared-packages` |
| **Previous** | PR 1: Shared Packages + elastic_assistant Refactor |
| **This PR** | PR 2: Plugin Scaffold + Step Registration (👈 you are here) |
| **Next** | PR 3: Internal API Routes + ES\|QL Mode |

> **Merging instructions for the author**: This PR currently targets `attack-discovery-workflows-integration/01-shared-packages` (PR 1's branch), which shows reviewers only this PR's incremental diff. After PR 1 merges into `elastic:main`:
> 1. Retarget this PR's base from `attack-discovery-workflows-integration/01-shared-packages` → `main` (GitHub: click Edit next to the title, change Base)
> 2. Verify the diff still shows only PR 2's files
> 3. Rebase locally: `~/stack-rebase.sh` then `git push origin -f`

This PR introduces the `discoveries` plugin, which implements the Attack Discovery Workflows integration. The plugin registers five workflow steps at `setup()` and creates six default workflow definitions at `start()`.

The plugin is gated by the `securitySolution.attackDiscoveryWorkflowsEnabled` feature flag. When the flag is OFF, the plugin performs no work and has zero side effects.

```yaml
feature_flags.overrides:
  securitySolution.attackDiscoveryWorkflowsEnabled: true
```

### Workflow Steps

| Step Type ID | Category | Purpose |
|---|---|---|
| `attack-discovery.defaultAlertRetrieval` | Elasticsearch | Retrieves and anonymizes alerts using query DSL or ES\|QL |
| `attack-discovery.generate` | AI | Generates attack discoveries from pre-retrieved alerts via LangGraph; emits event log entries |
| `attack-discovery.defaultValidation` | Kibana | Validates discoveries with hallucination detection and deduplication |
| `attack-discovery.persistDiscoveries` | Kibana | Persists validated discoveries to the Attack Discovery data store |
| `attack-discovery.run` | AI | High-level entry point: runs the full pipeline as a single step (sync or async) |

Steps use `@kbn/zod/v4` inline schemas (not generated v3 schemas) per the Workflows platform requirement. Each step has a common definition in `common/step_types/` shared between server registration and the step catalog UI.

### Default Workflow Definitions

| Workflow YAML | Purpose |
|---------------|---------|
| `default_attack_discovery_alert_retrieval` | Default alert retrieval (query DSL) — _required_ |
| `attack_discovery_generation` | Generation via LangGraph — _required_ |
| `attack_discovery_validate` | Validation + persistence — _required_ |
| `attack_discovery_esql_example` | Example: ES\|QL-based alert retrieval |
| `attack_discovery_custom_validation_example` | Example: custom validation with Liquid sort filter |
| `attack_discovery_run_example` | Example: full pipeline in one step |

### Platform Registrations

- `approved_step_definitions.ts`: 6 `attack-discovery.*` step entries (+24 lines)
- `agent-builder allow_lists.ts`: `'attack-discovery-alert-retrieval-builder'` skill (+1 line)
- `agent-builder type_definition.ts`: `'attack-discovery'` directory entry (+2 lines)

### Plugin Lifecycle

1. **`setup()`**: Registers 5 workflow steps via `tryRegisterStep` (with error tracking via `StepRegistrationResult`)
2. **`start()`**: Registers default workflow definitions per space, runs startup health check

## CODEOWNERS

`approved_step_definitions.ts` adds 6 `attack-discovery.*` step hashes — this file is owned by `@elastic/workflows-eng`. Please review the new entries for correctness. No behavioral changes to the platform step registry — purely additive.

_PR developed with Claude Code, Cursor + claude-4.6-opus, claude-4.6-sonnet,
GPT-5.2 High_